### PR TITLE
Put more sane defaults for repo_url

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -9,7 +9,7 @@ categories:
         instead of having a heterogeneous environment of...
       homepage_url: https://projects.eclipse.org/projects/automotive.arche
       project: Incubating
-      repo_url: https://github.com/eclipse-arche/arche
+      repo_url: https://github.com/eclipse-arche
       repo_urls:
       - https://github.com/eclipse-arche/arche
       - https://github.com/eclipse-arche/.eclipsefdn
@@ -27,16 +27,17 @@ categories:
         industry to establish a new, digital-first approach for the...
       homepage_url: https://projects.eclipse.org/projects/automotive.autowrx
       project: Incubating
-      repo_url: https://github.com/eclipse-autowrx/autowrx
+      repo_url: https://github.com/eclipse-autowrx
       repo_urls:
       - https://github.com/eclipse-autowrx/autowrx
+      - https://github.com/eclipse-autowrx/epam-service-connector
+      - https://github.com/eclipse-autowrx/sdv-blueprints
+      - https://github.com/eclipse-autowrx/.eclipsefdn
       - https://github.com/eclipse-autowrx/learning-journey
       - https://github.com/eclipse-autowrx/platform-services
       - https://github.com/eclipse-autowrx/platform-plugins
       - https://github.com/eclipse-autowrx/sample-replit-plugin
-      - https://github.com/eclipse-autowrx/.eclipsefdn
       - https://github.com/eclipse-autowrx/digital.auto-RIVOS-blueprint
-      - https://github.com/eclipse-autowrx/epam-service-connector
       - https://github.com/eclipse-autowrx/SDV4EE-demo
       - https://github.com/eclipse-autowrx/instance-setup
       - https://github.com/eclipse-autowrx/widget-3d-car-unity
@@ -51,10 +52,16 @@ categories:
       repositories:
       - url: https://github.com/eclipse-autowrx/autowrx
         latest_release:
-          tag_name: v3.1.1
-          name: Release v3.1.1
-          url: https://github.com/eclipse-autowrx/autowrx/releases/tag/v3.1.1
-          published_at: '2026-02-05T04:08:21Z'
+          tag_name: v3.5.1
+          name: Release v3.5.1
+          url: https://github.com/eclipse-autowrx/autowrx/releases/tag/v3.5.1
+          published_at: '2026-04-10T10:02:50Z'
+      - url: https://github.com/eclipse-autowrx/epam-service-connector
+        latest_release: null
+      - url: https://github.com/eclipse-autowrx/sdv-blueprints
+        latest_release: null
+      - url: https://github.com/eclipse-autowrx/.eclipsefdn
+        latest_release: null
       - url: https://github.com/eclipse-autowrx/learning-journey
         latest_release:
           tag_name: v1.1.2
@@ -67,11 +74,7 @@ categories:
         latest_release: null
       - url: https://github.com/eclipse-autowrx/sample-replit-plugin
         latest_release: null
-      - url: https://github.com/eclipse-autowrx/.eclipsefdn
-        latest_release: null
       - url: https://github.com/eclipse-autowrx/digital.auto-RIVOS-blueprint
-        latest_release: null
-      - url: https://github.com/eclipse-autowrx/epam-service-connector
         latest_release: null
       - url: https://github.com/eclipse-autowrx/SDV4EE-demo
         latest_release: null
@@ -123,7 +126,7 @@ categories:
         Currently, the automotive...'
       homepage_url: https://projects.eclipse.org/projects/automotive.velocitas
       project: Incubating
-      repo_url: https://github.com/eclipse-velocitas/vehicle-app-cpp-template
+      repo_url: https://github.com/eclipse-velocitas
       repo_urls:
       - https://github.com/eclipse-velocitas/vehicle-app-cpp-template
       - https://github.com/eclipse-velocitas/devcontainer-base-images
@@ -308,15 +311,15 @@ categories:
         Transfer existing signal-based ECUs to HPC...'
       homepage_url: https://projects.eclipse.org/projects/automotive.openvehicle-api
       project: Incubating
-      repo_url: https://github.com/eclipse-openvehicle-api/openvehicle-website
+      repo_url: https://github.com/eclipse-openvehicle-api
       repo_urls:
-      - https://github.com/eclipse-openvehicle-api/openvehicle-website
       - https://github.com/eclipse-openvehicle-api/openvehicle-api
+      - https://github.com/eclipse-openvehicle-api/openvehicle-website
       - https://github.com/eclipse-openvehicle-api/.eclipsefdn
       repositories:
-      - url: https://github.com/eclipse-openvehicle-api/openvehicle-website
-        latest_release: null
       - url: https://github.com/eclipse-openvehicle-api/openvehicle-api
+        latest_release: null
+      - url: https://github.com/eclipse-openvehicle-api/openvehicle-website
         latest_release: null
       - url: https://github.com/eclipse-openvehicle-api/.eclipsefdn
         latest_release: null
@@ -331,7 +334,7 @@ categories:
         Eclipse OpenXilEnv will provide a configurable...'
       homepage_url: https://projects.eclipse.org/projects/automotive.openxilenv
       project: Incubating
-      repo_url: https://github.com/eclipse-openxilenv/openxilenv
+      repo_url: https://github.com/eclipse-openxilenv
       repo_urls:
       - https://github.com/eclipse-openxilenv/openxilenv
       - https://github.com/eclipse-openxilenv/.eclipsefdn
@@ -339,7 +342,11 @@ categories:
       - https://github.com/eclipse-openxilenv/openxilenv-website
       repositories:
       - url: https://github.com/eclipse-openxilenv/openxilenv
-        latest_release: null
+        latest_release:
+          tag_name: snapshot-2026-04-28
+          name: snapshot-2026-04-28
+          url: https://github.com/eclipse-openxilenv/openxilenv/releases/tag/snapshot-2026-04-28
+          published_at: null
       - url: https://github.com/eclipse-openxilenv/.eclipsefdn
         latest_release: null
       - url: https://github.com/eclipse-openxilenv/.github
@@ -353,39 +360,39 @@ categories:
         the testing and validation process but also includes...
       homepage_url: https://projects.eclipse.org/projects/automotive.opendut
       project: Incubating
-      repo_url: https://github.com/eclipse-opendut/opendut
+      repo_url: https://github.com/eclipse-opendut
       repo_urls:
       - https://github.com/eclipse-opendut/opendut
       - https://github.com/eclipse-opendut/netbird-build
       - https://github.com/eclipse-opendut/netbird-fork
-      - https://github.com/eclipse-opendut/.eclipsefdn
       - https://github.com/eclipse-opendut/raspberry-pi-wireless-bootstrap
+      - https://github.com/eclipse-opendut/.eclipsefdn
       - https://github.com/eclipse-opendut/cannelloni-build
       - https://github.com/eclipse-opendut/.github
       - https://github.com/eclipse-opendut/rperf-build
       repositories:
       - url: https://github.com/eclipse-opendut/opendut
         latest_release:
-          tag_name: v0.10.0-alpha.0
-          name: v0.10.0-alpha.0
-          url: https://github.com/eclipse-opendut/opendut/releases/tag/v0.10.0-alpha.0
-          published_at: '2026-02-16T16:04:27Z'
+          tag_name: v0.10.1-alpha
+          name: v0.10.1-alpha
+          url: https://github.com/eclipse-opendut/opendut/releases/tag/v0.10.1-alpha
+          published_at: '2026-04-20T13:55:32Z'
       - url: https://github.com/eclipse-opendut/netbird-build
         latest_release:
-          tag_name: v0.64.5-59ad6325e348aa1f9e1098fed1a4d45eaeadffc7
-          name: v0.64.5-59ad6325e348aa1f9e1098fed1a4d45eaeadffc7
-          url: https://github.com/eclipse-opendut/netbird-build/releases/tag/v0.64.5-59ad6325e348aa1f9e1098fed1a4d45eaeadffc7
-          published_at: '2026-02-06T09:22:57Z'
+          tag_name: v0.68.2-543b4b5004d52fdf3cfdda205fedf87bfd3206e6
+          name: v0.68.2-543b4b5004d52fdf3cfdda205fedf87bfd3206e6
+          url: https://github.com/eclipse-opendut/netbird-build/releases/tag/v0.68.2-543b4b5004d52fdf3cfdda205fedf87bfd3206e6
+          published_at: '2026-04-17T07:03:37Z'
       - url: https://github.com/eclipse-opendut/netbird-fork
-        latest_release: null
-      - url: https://github.com/eclipse-opendut/.eclipsefdn
         latest_release: null
       - url: https://github.com/eclipse-opendut/raspberry-pi-wireless-bootstrap
         latest_release:
-          tag_name: v0.1.1
-          name: 0.1.1
-          url: https://github.com/eclipse-opendut/raspberry-pi-wireless-bootstrap/releases/tag/v0.1.1
-          published_at: '2025-05-28T14:18:19Z'
+          tag_name: v0.1.2
+          name: ''
+          url: https://github.com/eclipse-opendut/raspberry-pi-wireless-bootstrap/releases/tag/v0.1.2
+          published_at: '2026-04-08T11:52:18Z'
+      - url: https://github.com/eclipse-opendut/.eclipsefdn
+        latest_release: null
       - url: https://github.com/eclipse-opendut/cannelloni-build
         latest_release:
           tag_name: v1.1.0
@@ -405,16 +412,16 @@ categories:
         can be used  to introspect, monitor and manipulate the...
       homepage_url: https://projects.eclipse.org/projects/automotive.muto
       project: Incubating
-      repo_url: https://github.com/eclipse-muto/muto
+      repo_url: https://github.com/eclipse-muto
       repo_urls:
-      - https://github.com/eclipse-muto/muto
       - https://github.com/eclipse-muto/composer
       - https://github.com/eclipse-muto/agent
-      - https://github.com/eclipse-muto/.github
+      - https://github.com/eclipse-muto/muto
+      - https://github.com/eclipse-muto/core
       - https://github.com/eclipse-muto/messages
+      - https://github.com/eclipse-muto/.github
       - https://github.com/eclipse-muto/.eclipsefdn
       - https://github.com/eclipse-muto/docs
-      - https://github.com/eclipse-muto/core
       - https://github.com/eclipse-muto/dashboard-device
       - https://github.com/eclipse-muto/liveui
       - https://github.com/eclipse-muto/liveui-react-native
@@ -425,25 +432,25 @@ categories:
       - https://github.com/eclipse-muto/liveui-vue
       - https://github.com/eclipse-muto/liveui-samples
       repositories:
-      - url: https://github.com/eclipse-muto/muto
-        latest_release: &id001
-          tag_name: v0.42_build_1
-          name: v0.42_build_1
-          url: https://github.com/eclipse-muto/muto/releases/tag/v0.42_build_1
-          published_at: '2025-09-28T17:37:25Z'
       - url: https://github.com/eclipse-muto/composer
         latest_release: null
       - url: https://github.com/eclipse-muto/agent
         latest_release: null
-      - url: https://github.com/eclipse-muto/.github
+      - url: https://github.com/eclipse-muto/muto
+        latest_release: &id001
+          tag_name: v0.42_build_2
+          name: v0.42_build_2
+          url: https://github.com/eclipse-muto/muto/releases/tag/v0.42_build_2
+          published_at: '2026-03-11T08:31:27Z'
+      - url: https://github.com/eclipse-muto/core
         latest_release: null
       - url: https://github.com/eclipse-muto/messages
+        latest_release: null
+      - url: https://github.com/eclipse-muto/.github
         latest_release: null
       - url: https://github.com/eclipse-muto/.eclipsefdn
         latest_release: null
       - url: https://github.com/eclipse-muto/docs
-        latest_release: null
-      - url: https://github.com/eclipse-muto/core
         latest_release: null
       - url: https://github.com/eclipse-muto/dashboard-device
         latest_release: null
@@ -484,31 +491,33 @@ categories:
         components into a coherent and useful whole: all the...'
       homepage_url: https://projects.eclipse.org/projects/automotive.leda
       project: Incubating
-      repo_url: https://github.com/eclipse-leda/leda-distro
+      repo_url: https://github.com/eclipse-leda
       repo_urls:
-      - https://github.com/eclipse-leda/leda-distro
       - https://github.com/eclipse-leda/meta-leda
+      - https://github.com/eclipse-leda/leda
+      - https://github.com/eclipse-leda/leda-distro
       - https://github.com/eclipse-leda/leda-utils
       - https://github.com/eclipse-leda/.github
       - https://github.com/eclipse-leda/.eclipsefdn
-      - https://github.com/eclipse-leda/leda
       - https://github.com/eclipse-leda/leda-example-applications
       - https://github.com/eclipse-leda/leda-contrib-vscode-extensions
       - https://github.com/eclipse-leda/eclipse-leda.github.io
       - https://github.com/eclipse-leda/leda-contrib-container-update-agent
       repositories:
-      - url: https://github.com/eclipse-leda/leda-distro
-        latest_release:
-          tag_name: v0.1.0-M3
-          name: Milestone v0.1.0-M3
-          url: https://github.com/eclipse-leda/leda-distro/releases/tag/v0.1.0-M3
-          published_at: '2023-11-20T13:56:48Z'
       - url: https://github.com/eclipse-leda/meta-leda
         latest_release:
           tag_name: 0.1.0-M3
           name: Milestone 0.1.0-M3
           url: https://github.com/eclipse-leda/meta-leda/releases/tag/0.1.0-M3
           published_at: '2023-11-14T13:28:30Z'
+      - url: https://github.com/eclipse-leda/leda
+        latest_release: null
+      - url: https://github.com/eclipse-leda/leda-distro
+        latest_release:
+          tag_name: v0.1.0-M3
+          name: Milestone v0.1.0-M3
+          url: https://github.com/eclipse-leda/leda-distro/releases/tag/v0.1.0-M3
+          published_at: '2023-11-20T13:56:48Z'
       - url: https://github.com/eclipse-leda/leda-utils
         latest_release:
           tag_name: v0.0.4
@@ -518,8 +527,6 @@ categories:
       - url: https://github.com/eclipse-leda/.github
         latest_release: null
       - url: https://github.com/eclipse-leda/.eclipsefdn
-        latest_release: null
-      - url: https://github.com/eclipse-leda/leda
         latest_release: null
       - url: https://github.com/eclipse-leda/leda-example-applications
         latest_release:
@@ -565,7 +572,7 @@ categories:
         provides libraries forlifecycle (startup/shutdown...
       homepage_url: https://projects.eclipse.org/projects/automotive.openbsw
       project: Incubating
-      repo_url: https://github.com/eclipse-openbsw/openbsw
+      repo_url: https://github.com/eclipse-openbsw
       repo_urls:
       - https://github.com/eclipse-openbsw/openbsw
       - https://github.com/eclipse-openbsw/openbsw-zephyr
@@ -605,86 +612,139 @@ categories:
         high-performance Electronic Control Units...
       homepage_url: https://projects.eclipse.org/projects/automotive.score
       project: Incubating
-      repo_url: https://github.com/eclipse-score/reference_integration
+      repo_url: https://github.com/eclipse-score
       repo_urls:
+      - https://github.com/eclipse-score/communication
+      - https://github.com/eclipse-score/baselibs
+      - https://github.com/eclipse-score/.github
+      - https://github.com/eclipse-score/itf
+      - https://github.com/eclipse-score/eclipse-score-website-preview
+      - https://github.com/eclipse-score/score
+      - https://github.com/eclipse-score/lifecycle
       - https://github.com/eclipse-score/reference_integration
+      - https://github.com/eclipse-score/tooling
+      - https://github.com/eclipse-score/persistency
+      - https://github.com/eclipse-score/.eclipsefdn
       - https://github.com/eclipse-score/bazel_registry_ui
       - https://github.com/eclipse-score/bazel_registry
-      - https://github.com/eclipse-score/rules_imagefs
-      - https://github.com/eclipse-score/process_description
-      - https://github.com/eclipse-score/inc_someip_gateway
-      - https://github.com/eclipse-score/score
-      - https://github.com/eclipse-score/bazel_cpp_toolchains
-      - https://github.com/eclipse-score/baselibs
-      - https://github.com/eclipse-score/lifecycle
-      - https://github.com/eclipse-score/rules_rust
-      - https://github.com/eclipse-score/persistency
-      - https://github.com/eclipse-score/feo
-      - https://github.com/eclipse-score/bazel_platforms
-      - https://github.com/eclipse-score/eclipse-score-website-preview
-      - https://github.com/eclipse-score/docs-as-code
-      - https://github.com/eclipse-score/communication
-      - https://github.com/eclipse-score/nlohmann_json
-      - https://github.com/eclipse-score/kyron
       - https://github.com/eclipse-score/logging
-      - https://github.com/eclipse-score/devcontainer
-      - https://github.com/eclipse-score/orchestrator
-      - https://github.com/eclipse-score/cicd-workflows
-      - https://github.com/eclipse-score/tools
-      - https://github.com/eclipse-score/tooling
-      - https://github.com/eclipse-score/baselibs_rust
-      - https://github.com/eclipse-score/itf
-      - https://github.com/eclipse-score/testing_tools
-      - https://github.com/eclipse-score/infrastructure
-      - https://github.com/eclipse-score/.eclipsefdn
-      - https://github.com/eclipse-score/scrample
-      - https://github.com/eclipse-score/inc_os_autosd
-      - https://github.com/eclipse-score/toolchains_rust
-      - https://github.com/eclipse-score/dash-license-scan
-      - https://github.com/eclipse-score/toolchains_qnx
-      - https://github.com/eclipse-score/score-crates
-      - https://github.com/eclipse-score/inc_time
-      - https://github.com/eclipse-score/score_rust_policies
-      - https://github.com/eclipse-score/.github
-      - https://github.com/eclipse-score/module_template
-      - https://github.com/eclipse-score/config_management
-      - https://github.com/eclipse-score/ferrocene_toolchain_builder
-      - https://github.com/eclipse-score/bazel-tools-cc
-      - https://github.com/eclipse-score/inc_security_crypto
-      - https://github.com/eclipse-score/inc_score_codegen
       - https://github.com/eclipse-score/toolchains_gcc_packages
-      - https://github.com/eclipse-score/more-disk-space
+      - https://github.com/eclipse-score/process_description
+      - https://github.com/eclipse-score/docs-as-code
+      - https://github.com/eclipse-score/inc_someip_gateway
+      - https://github.com/eclipse-score/nlohmann_json
+      - https://github.com/eclipse-score/module_template
+      - https://github.com/eclipse-score/devcontainer
+      - https://github.com/eclipse-score/inc_security_crypto
+      - https://github.com/eclipse-score/inc_time
       - https://github.com/eclipse-score/inc_daal
-      - https://github.com/eclipse-score/inc_mw_com
-      - https://github.com/eclipse-score/eclipse-score.github.io
+      - https://github.com/eclipse-score/kyron
+      - https://github.com/eclipse-score/orchestrator
+      - https://github.com/eclipse-score/testing_tools
+      - https://github.com/eclipse-score/bazel_cpp_toolchains
+      - https://github.com/eclipse-score/baselibs_rust
+      - https://github.com/eclipse-score/scrample
+      - https://github.com/eclipse-score/toolchains_rust
+      - https://github.com/eclipse-score/ferrocene_toolchain_builder
+      - https://github.com/eclipse-score/rules_rust
+      - https://github.com/eclipse-score/more-disk-space
+      - https://github.com/eclipse-score/cicd-workflows
+      - https://github.com/eclipse-score/cicd-actions
+      - https://github.com/eclipse-score/feo
+      - https://github.com/eclipse-score/inc_os_autosd
+      - https://github.com/eclipse-score/infrastructure
+      - https://github.com/eclipse-score/rules_imagefs
+      - https://github.com/eclipse-score/os_images
+      - https://github.com/eclipse-score/inc_diagnostics
+      - https://github.com/eclipse-score/score-crates
+      - https://github.com/eclipse-score/tools
+      - https://github.com/eclipse-score/qnx_unit_tests
       - https://github.com/eclipse-score/eclipse-score-website-published
       - https://github.com/eclipse-score/eclipse-score-website
-      - https://github.com/eclipse-score/inc_abi_compatible_datatypes
+      - https://github.com/eclipse-score/sbom-tool
+      - https://github.com/eclipse-score/config_management
+      - https://github.com/eclipse-score/apt-install
       - https://github.com/eclipse-score/bazel-tools-python
+      - https://github.com/eclipse-score/bazel-tools-cc
+      - https://github.com/eclipse-score/bazel_platforms
+      - https://github.com/eclipse-score/score_rust_policies
       - https://github.com/eclipse-score/toolchains_gcc
-      - https://github.com/eclipse-score/os_images
+      - https://github.com/eclipse-score/toolchains_qnx
+      - https://github.com/eclipse-score/dev_playground
+      - https://github.com/eclipse-score/test_module_a
+      - https://github.com/eclipse-score/test_module_b
+      - https://github.com/eclipse-score/operating_system
+      - https://github.com/eclipse-score/dash-license-scan
+      - https://github.com/eclipse-score/score_cpp_policies
+      - https://github.com/eclipse-score/inc_score_codegen
+      - https://github.com/eclipse-score/inc_mw_com
+      - https://github.com/eclipse-score/eclipse-score.github.io
+      - https://github.com/eclipse-score/inc_abi_compatible_datatypes
       - https://github.com/eclipse-score/inc_config_management
       - https://github.com/eclipse-score/inc_mw_log
       - https://github.com/eclipse-score/inc_gen_ai
-      - https://github.com/eclipse-score/inc_diagnostics
       - https://github.com/eclipse-score/inc_ai_platform
-      - https://github.com/eclipse-score/test_module_a
-      - https://github.com/eclipse-score/test_module_b
       - https://github.com/eclipse-score/test_integration
       - https://github.com/eclipse-score/inc_feo
       - https://github.com/eclipse-score/inc_json
       - https://github.com/eclipse-score/inc_process_variant_management
       - https://github.com/eclipse-score/examples
-      - https://github.com/eclipse-score/operating_system
       - https://github.com/eclipse-score/inc_process_test_management
-      - https://github.com/eclipse-score/apt-install
       repositories:
+      - url: https://github.com/eclipse-score/communication
+        latest_release:
+          tag_name: v0.2.1
+          name: v0.2.1
+          url: https://github.com/eclipse-score/communication/releases/tag/v0.2.1
+          published_at: '2026-04-29T04:52:51Z'
+      - url: https://github.com/eclipse-score/baselibs
+        latest_release:
+          tag_name: v0.2.7
+          name: v0.2.7
+          url: https://github.com/eclipse-score/baselibs/releases/tag/v0.2.7
+          published_at: '2026-04-29T13:23:57Z'
+      - url: https://github.com/eclipse-score/.github
+        latest_release: null
+      - url: https://github.com/eclipse-score/itf
+        latest_release:
+          tag_name: 0.3.0
+          name: 0.3.0
+          url: https://github.com/eclipse-score/itf/releases/tag/0.3.0
+          published_at: '2026-04-22T08:50:37Z'
+      - url: https://github.com/eclipse-score/eclipse-score-website-preview
+        latest_release: null
+      - url: https://github.com/eclipse-score/score
+        latest_release:
+          tag_name: v0.5.5
+          name: v0.5.5
+          url: https://github.com/eclipse-score/score/releases/tag/v0.5.5
+          published_at: '2026-04-26T12:32:45Z'
+      - url: https://github.com/eclipse-score/lifecycle
+        latest_release:
+          tag_name: v0.2.0
+          name: v0.2.0
+          url: https://github.com/eclipse-score/lifecycle/releases/tag/v0.2.0
+          published_at: '2026-04-29T08:27:42Z'
       - url: https://github.com/eclipse-score/reference_integration
         latest_release:
-          tag_name: v0.5.0-beta
-          name: v0.5.0-beta
-          url: https://github.com/eclipse-score/reference_integration/releases/tag/v0.5.0-beta
-          published_at: '2025-12-22T14:55:11Z'
+          tag_name: v0.6.0
+          name: v0.6.0 (RETRACTED – do not use)
+          url: https://github.com/eclipse-score/reference_integration/releases/tag/v0.6.0
+          published_at: '2026-02-23T11:06:08Z'
+      - url: https://github.com/eclipse-score/tooling
+        latest_release:
+          tag_name: v1.2.0
+          name: v1.2.0
+          url: https://github.com/eclipse-score/tooling/releases/tag/v1.2.0
+          published_at: '2026-04-02T14:17:01Z'
+      - url: https://github.com/eclipse-score/persistency
+        latest_release:
+          tag_name: v0.3.1
+          name: v0.3.1
+          url: https://github.com/eclipse-score/persistency/releases/tag/v0.3.1
+          published_at: '2026-04-30T13:06:45Z'
+      - url: https://github.com/eclipse-score/.eclipsefdn
+        latest_release: null
       - url: https://github.com/eclipse-score/bazel_registry_ui
         latest_release: null
       - url: https://github.com/eclipse-score/bazel_registry
@@ -693,239 +753,231 @@ categories:
           name: v0.5.0-beta
           url: https://github.com/eclipse-score/bazel_registry/releases/tag/v0.5.0-beta
           published_at: '2025-12-22T12:39:41Z'
-      - url: https://github.com/eclipse-score/rules_imagefs
-        latest_release: null
-      - url: https://github.com/eclipse-score/process_description
-        latest_release:
-          tag_name: v1.4.3
-          name: v1.4.3
-          url: https://github.com/eclipse-score/process_description/releases/tag/v1.4.3
-          published_at: '2026-02-05T04:55:56Z'
-      - url: https://github.com/eclipse-score/inc_someip_gateway
-        latest_release: null
-      - url: https://github.com/eclipse-score/score
-        latest_release:
-          tag_name: v0.5.3
-          name: v0.5.3
-          url: https://github.com/eclipse-score/score/releases/tag/v0.5.3
-          published_at: '2026-02-10T17:36:17Z'
-      - url: https://github.com/eclipse-score/bazel_cpp_toolchains
-        latest_release:
-          tag_name: v0.3.0
-          name: v0.3.0
-          url: https://github.com/eclipse-score/bazel_cpp_toolchains/releases/tag/v0.3.0
-          published_at: '2026-02-18T15:07:48Z'
-      - url: https://github.com/eclipse-score/baselibs
-        latest_release:
-          tag_name: v0.2.4
-          name: v0.2.4
-          url: https://github.com/eclipse-score/baselibs/releases/tag/v0.2.4
-          published_at: '2026-02-16T17:11:03Z'
-      - url: https://github.com/eclipse-score/lifecycle
-        latest_release:
-          tag_name: v0.1.0
-          name: v0.1.0
-          url: https://github.com/eclipse-score/lifecycle/releases/tag/v0.1.0
-          published_at: '2026-02-17T11:19:23Z'
-      - url: https://github.com/eclipse-score/rules_rust
-        latest_release:
-          tag_name: 0.68.1-score
-          name: 0.68.1-score
-          url: https://github.com/eclipse-score/rules_rust/releases/tag/0.68.1-score
-          published_at: '2026-02-18T13:40:12Z'
-      - url: https://github.com/eclipse-score/persistency
-        latest_release:
-          tag_name: v0.3.0
-          name: v0.3.0
-          url: https://github.com/eclipse-score/persistency/releases/tag/v0.3.0
-          published_at: '2026-02-17T09:57:46Z'
-      - url: https://github.com/eclipse-score/feo
-        latest_release:
-          tag_name: v1.0.3
-          name: v1.0.3
-          url: https://github.com/eclipse-score/feo/releases/tag/v1.0.3
-          published_at: '2026-02-11T11:04:02Z'
-      - url: https://github.com/eclipse-score/bazel_platforms
-        latest_release:
-          tag_name: v0.1.1
-          name: v0.1.1
-          url: https://github.com/eclipse-score/bazel_platforms/releases/tag/v0.1.1
-          published_at: '2026-02-18T10:27:49Z'
-      - url: https://github.com/eclipse-score/eclipse-score-website-preview
-        latest_release: null
-      - url: https://github.com/eclipse-score/docs-as-code
-        latest_release:
-          tag_name: v3.0.1
-          name: v3.0.1
-          url: https://github.com/eclipse-score/docs-as-code/releases/tag/v3.0.1
-          published_at: '2026-02-13T08:43:35Z'
-      - url: https://github.com/eclipse-score/communication
-        latest_release:
-          tag_name: v0.1.2
-          name: v0.1.2
-          url: https://github.com/eclipse-score/communication/releases/tag/v0.1.2
-          published_at: '2025-12-19T14:31:08Z'
-      - url: https://github.com/eclipse-score/nlohmann_json
-        latest_release: null
-      - url: https://github.com/eclipse-score/kyron
-        latest_release:
-          tag_name: v0.1.1
-          name: v0.1.1
-          url: https://github.com/eclipse-score/kyron/releases/tag/v0.1.1
-          published_at: '2026-02-17T09:19:14Z'
       - url: https://github.com/eclipse-score/logging
         latest_release:
-          tag_name: v0.0.5
-          name: v0.0.5
-          url: https://github.com/eclipse-score/logging/releases/tag/v0.0.5
-          published_at: '2026-02-03T09:01:05Z'
-      - url: https://github.com/eclipse-score/devcontainer
-        latest_release:
-          tag_name: v1.1.0
-          name: v1.1.0
-          url: https://github.com/eclipse-score/devcontainer/releases/tag/v1.1.0
-          published_at: '2025-11-28T15:59:22Z'
-      - url: https://github.com/eclipse-score/orchestrator
-        latest_release:
-          tag_name: v0.1.0
-          name: v0.1.0
-          url: https://github.com/eclipse-score/orchestrator/releases/tag/v0.1.0
-          published_at: '2026-02-17T09:16:10Z'
-      - url: https://github.com/eclipse-score/cicd-workflows
-        latest_release: null
-      - url: https://github.com/eclipse-score/tools
-        latest_release: null
-      - url: https://github.com/eclipse-score/tooling
-        latest_release:
-          tag_name: v1.1.2-RC
-          name: v1.1.2-RC
-          url: https://github.com/eclipse-score/tooling/releases/tag/v1.1.2-RC
-          published_at: '2026-02-13T08:29:04Z'
-      - url: https://github.com/eclipse-score/baselibs_rust
-        latest_release:
-          tag_name: v0.1.0
-          name: v0.1.0
-          url: https://github.com/eclipse-score/baselibs_rust/releases/tag/v0.1.0
-          published_at: '2026-02-10T14:44:19Z'
-      - url: https://github.com/eclipse-score/itf
-        latest_release:
-          tag_name: 0.1.0
-          name: 0.1.0
-          url: https://github.com/eclipse-score/itf/releases/tag/0.1.0
-          published_at: '2025-09-23T12:51:53Z'
-      - url: https://github.com/eclipse-score/testing_tools
-        latest_release:
-          tag_name: v0.3.1
-          name: v0.3.1
-          url: https://github.com/eclipse-score/testing_tools/releases/tag/v0.3.1
-          published_at: '2025-12-16T09:07:35Z'
-      - url: https://github.com/eclipse-score/infrastructure
-        latest_release: null
-      - url: https://github.com/eclipse-score/.eclipsefdn
-        latest_release: null
-      - url: https://github.com/eclipse-score/scrample
-        latest_release:
-          tag_name: v0.1.1
-          name: v0.1.1
-          url: https://github.com/eclipse-score/scrample/releases/tag/v0.1.1
-          published_at: '2026-01-26T13:25:47Z'
-      - url: https://github.com/eclipse-score/inc_os_autosd
-        latest_release:
-          tag_name: continuous
-          name: Continuous Build
-          url: https://github.com/eclipse-score/inc_os_autosd/releases/tag/continuous
-          published_at: '2026-02-10T12:23:31Z'
-      - url: https://github.com/eclipse-score/toolchains_rust
-        latest_release:
-          tag_name: v0.7.0
-          name: v0.7.0
-          url: https://github.com/eclipse-score/toolchains_rust/releases/tag/v0.7.0
-          published_at: '2026-02-10T11:03:47Z'
-      - url: https://github.com/eclipse-score/dash-license-scan
-        latest_release:
-          tag_name: v0.0.1a1
-          name: v0.0.1a1 - First Release Attempt
-          url: https://github.com/eclipse-score/dash-license-scan/releases/tag/v0.0.1a1
-          published_at: '2025-12-19T07:02:56Z'
-      - url: https://github.com/eclipse-score/toolchains_qnx
-        latest_release:
-          tag_name: v0.0.7
-          name: v0.0.7
-          url: https://github.com/eclipse-score/toolchains_qnx/releases/tag/v0.0.7
-          published_at: '2026-02-09T14:15:07Z'
-      - url: https://github.com/eclipse-score/score-crates
-        latest_release:
-          tag_name: v0.0.7
-          name: v0.0.7
-          url: https://github.com/eclipse-score/score-crates/releases/tag/v0.0.7
-          published_at: '2026-02-09T09:19:40Z'
-      - url: https://github.com/eclipse-score/inc_time
-        latest_release: null
-      - url: https://github.com/eclipse-score/score_rust_policies
-        latest_release:
-          tag_name: 0.0.5
-          name: 0.0.5
-          url: https://github.com/eclipse-score/score_rust_policies/releases/tag/0.0.5
-          published_at: '2026-02-05T12:08:56Z'
-      - url: https://github.com/eclipse-score/.github
-        latest_release: null
-      - url: https://github.com/eclipse-score/module_template
-        latest_release: null
-      - url: https://github.com/eclipse-score/config_management
-        latest_release: null
-      - url: https://github.com/eclipse-score/ferrocene_toolchain_builder
-        latest_release:
-          tag_name: 1.0.1
-          name: 'Ferrocene Toolchain Release '
-          url: https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/tag/1.0.1
-          published_at: '2026-01-14T15:06:47Z'
-      - url: https://github.com/eclipse-score/bazel-tools-cc
-        latest_release:
-          tag_name: v0.1.0
-          name: v0.1.0
-          url: https://github.com/eclipse-score/bazel-tools-cc/releases/tag/v0.1.0
-          published_at: '2025-12-15T06:13:22Z'
-      - url: https://github.com/eclipse-score/inc_security_crypto
-        latest_release: null
-      - url: https://github.com/eclipse-score/inc_score_codegen
-        latest_release: null
+          tag_name: v0.2.1
+          name: v0.2.1
+          url: https://github.com/eclipse-score/logging/releases/tag/v0.2.1
+          published_at: '2026-05-04T11:38:01Z'
       - url: https://github.com/eclipse-score/toolchains_gcc_packages
         latest_release:
           tag_name: v0.0.4
           name: v0.0.4
           url: https://github.com/eclipse-score/toolchains_gcc_packages/releases/tag/v0.0.4
           published_at: '2026-01-21T14:32:03Z'
+      - url: https://github.com/eclipse-score/process_description
+        latest_release:
+          tag_name: v1.5.4
+          name: v1.5.4
+          url: https://github.com/eclipse-score/process_description/releases/tag/v1.5.4
+          published_at: '2026-04-23T09:00:43Z'
+      - url: https://github.com/eclipse-score/docs-as-code
+        latest_release:
+          tag_name: v4.0.3
+          name: v4.0.3
+          url: https://github.com/eclipse-score/docs-as-code/releases/tag/v4.0.3
+          published_at: '2026-04-23T10:33:17Z'
+      - url: https://github.com/eclipse-score/inc_someip_gateway
+        latest_release: null
+      - url: https://github.com/eclipse-score/nlohmann_json
+        latest_release:
+          tag_name: v3.12.0-tsf.1
+          name: v3.12.0-tsf.1
+          url: https://github.com/eclipse-score/nlohmann_json/releases/tag/v3.12.0-tsf.1
+          published_at: '2026-04-29T09:16:21Z'
+      - url: https://github.com/eclipse-score/module_template
+        latest_release: null
+      - url: https://github.com/eclipse-score/devcontainer
+        latest_release:
+          tag_name: v1.5.0
+          name: v1.5.0
+          url: https://github.com/eclipse-score/devcontainer/releases/tag/v1.5.0
+          published_at: '2026-05-04T00:28:04Z'
+      - url: https://github.com/eclipse-score/inc_security_crypto
+        latest_release: null
+      - url: https://github.com/eclipse-score/inc_time
+        latest_release: null
+      - url: https://github.com/eclipse-score/inc_daal
+        latest_release: null
+      - url: https://github.com/eclipse-score/kyron
+        latest_release:
+          tag_name: v0.1.2
+          name: v0.1.2
+          url: https://github.com/eclipse-score/kyron/releases/tag/v0.1.2
+          published_at: '2026-04-30T08:59:56Z'
+      - url: https://github.com/eclipse-score/orchestrator
+        latest_release:
+          tag_name: v0.1.1
+          name: v0.1.1
+          url: https://github.com/eclipse-score/orchestrator/releases/tag/v0.1.1
+          published_at: '2026-04-30T09:23:42Z'
+      - url: https://github.com/eclipse-score/testing_tools
+        latest_release:
+          tag_name: v0.4.1
+          name: v0.4.1
+          url: https://github.com/eclipse-score/testing_tools/releases/tag/v0.4.1
+          published_at: '2026-04-29T19:20:34Z'
+      - url: https://github.com/eclipse-score/bazel_cpp_toolchains
+        latest_release:
+          tag_name: v0.5.1
+          name: v0.5.1
+          url: https://github.com/eclipse-score/bazel_cpp_toolchains/releases/tag/v0.5.1
+          published_at: '2026-04-15T13:45:16Z'
+      - url: https://github.com/eclipse-score/baselibs_rust
+        latest_release:
+          tag_name: v0.1.2
+          name: v0.1.2
+          url: https://github.com/eclipse-score/baselibs_rust/releases/tag/v0.1.2
+          published_at: '2026-04-27T11:27:00Z'
+      - url: https://github.com/eclipse-score/scrample
+        latest_release:
+          tag_name: v0.1.1
+          name: v0.1.1
+          url: https://github.com/eclipse-score/scrample/releases/tag/v0.1.1
+          published_at: '2026-01-26T13:25:47Z'
+      - url: https://github.com/eclipse-score/toolchains_rust
+        latest_release:
+          tag_name: v0.9.1
+          name: v0.9.1
+          url: https://github.com/eclipse-score/toolchains_rust/releases/tag/v0.9.1
+          published_at: '2026-04-27T14:40:53Z'
+      - url: https://github.com/eclipse-score/ferrocene_toolchain_builder
+        latest_release:
+          tag_name: 1.2.0
+          name: Ferrocene Toolchain Release
+          url: https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/tag/1.2.0
+          published_at: '2026-03-16T15:48:25Z'
+      - url: https://github.com/eclipse-score/rules_rust
+        latest_release:
+          tag_name: 0.68.2-score
+          name: 0.68.2-score
+          url: https://github.com/eclipse-score/rules_rust/releases/tag/0.68.2-score
+          published_at: '2026-04-27T07:33:19Z'
       - url: https://github.com/eclipse-score/more-disk-space
         latest_release:
           tag_name: v1
           name: v1
           url: https://github.com/eclipse-score/more-disk-space/releases/tag/v1
           published_at: null
-      - url: https://github.com/eclipse-score/inc_daal
+      - url: https://github.com/eclipse-score/cicd-workflows
+        latest_release:
+          tag_name: v0.0.1
+          name: v0.0.1
+          url: https://github.com/eclipse-score/cicd-workflows/releases/tag/v0.0.1
+          published_at: null
+      - url: https://github.com/eclipse-score/cicd-actions
         latest_release: null
-      - url: https://github.com/eclipse-score/inc_mw_com
+      - url: https://github.com/eclipse-score/feo
+        latest_release:
+          tag_name: v1.0.5
+          name: v1.0.5
+          url: https://github.com/eclipse-score/feo/releases/tag/v1.0.5
+          published_at: '2026-02-19T13:44:59Z'
+      - url: https://github.com/eclipse-score/inc_os_autosd
+        latest_release:
+          tag_name: continuous
+          name: Continuous Build
+          url: https://github.com/eclipse-score/inc_os_autosd/releases/tag/continuous
+          published_at: '2026-03-24T15:58:16Z'
+      - url: https://github.com/eclipse-score/infrastructure
         latest_release: null
-      - url: https://github.com/eclipse-score/eclipse-score.github.io
+      - url: https://github.com/eclipse-score/rules_imagefs
+        latest_release:
+          tag_name: v0.0.3
+          name: v0.0.3
+          url: https://github.com/eclipse-score/rules_imagefs/releases/tag/v0.0.3
+          published_at: '2026-04-02T12:58:50Z'
+      - url: https://github.com/eclipse-score/os_images
         latest_release: null
+      - url: https://github.com/eclipse-score/inc_diagnostics
+        latest_release: null
+      - url: https://github.com/eclipse-score/score-crates
+        latest_release:
+          tag_name: v0.0.9
+          name: v0.0.9
+          url: https://github.com/eclipse-score/score-crates/releases/tag/v0.0.9
+          published_at: '2026-03-25T11:15:33Z'
+      - url: https://github.com/eclipse-score/tools
+        latest_release: null
+      - url: https://github.com/eclipse-score/qnx_unit_tests
+        latest_release:
+          tag_name: 0.1.0
+          name: 0.1.0
+          url: https://github.com/eclipse-score/qnx_unit_tests/releases/tag/0.1.0
+          published_at: '2026-04-09T12:37:33Z'
       - url: https://github.com/eclipse-score/eclipse-score-website-published
         latest_release: null
       - url: https://github.com/eclipse-score/eclipse-score-website
         latest_release: null
-      - url: https://github.com/eclipse-score/inc_abi_compatible_datatypes
+      - url: https://github.com/eclipse-score/sbom-tool
         latest_release: null
+      - url: https://github.com/eclipse-score/config_management
+        latest_release: null
+      - url: https://github.com/eclipse-score/apt-install
+        latest_release:
+          tag_name: v1.0.0
+          name: v1.0.0
+          url: https://github.com/eclipse-score/apt-install/releases/tag/v1.0.0
+          published_at: null
       - url: https://github.com/eclipse-score/bazel-tools-python
         latest_release:
           tag_name: v0.1.3
           name: v0.1.3
           url: https://github.com/eclipse-score/bazel-tools-python/releases/tag/v0.1.3
           published_at: '2025-11-25T13:52:14Z'
+      - url: https://github.com/eclipse-score/bazel-tools-cc
+        latest_release:
+          tag_name: v0.1.0
+          name: v0.1.0
+          url: https://github.com/eclipse-score/bazel-tools-cc/releases/tag/v0.1.0
+          published_at: '2025-12-15T06:13:22Z'
+      - url: https://github.com/eclipse-score/bazel_platforms
+        latest_release:
+          tag_name: v0.1.2
+          name: v0.1.2
+          url: https://github.com/eclipse-score/bazel_platforms/releases/tag/v0.1.2
+          published_at: '2026-03-26T10:49:58Z'
+      - url: https://github.com/eclipse-score/score_rust_policies
+        latest_release:
+          tag_name: 0.0.5
+          name: 0.0.5
+          url: https://github.com/eclipse-score/score_rust_policies/releases/tag/0.0.5
+          published_at: '2026-02-05T12:08:56Z'
       - url: https://github.com/eclipse-score/toolchains_gcc
         latest_release:
           tag_name: v0.0.7
           name: v0.0.7
           url: https://github.com/eclipse-score/toolchains_gcc/releases/tag/v0.0.7
           published_at: '2025-12-02T16:15:45Z'
-      - url: https://github.com/eclipse-score/os_images
+      - url: https://github.com/eclipse-score/toolchains_qnx
+        latest_release:
+          tag_name: v0.0.7
+          name: v0.0.7
+          url: https://github.com/eclipse-score/toolchains_qnx/releases/tag/v0.0.7
+          published_at: '2026-02-09T14:15:07Z'
+      - url: https://github.com/eclipse-score/dev_playground
+        latest_release: null
+      - url: https://github.com/eclipse-score/test_module_a
+        latest_release: null
+      - url: https://github.com/eclipse-score/test_module_b
+        latest_release: null
+      - url: https://github.com/eclipse-score/operating_system
+        latest_release: null
+      - url: https://github.com/eclipse-score/dash-license-scan
+        latest_release:
+          tag_name: v0.0.1a1
+          name: v0.0.1a1 - First Release Attempt
+          url: https://github.com/eclipse-score/dash-license-scan/releases/tag/v0.0.1a1
+          published_at: '2025-12-19T07:02:56Z'
+      - url: https://github.com/eclipse-score/score_cpp_policies
+        latest_release: null
+      - url: https://github.com/eclipse-score/inc_score_codegen
+        latest_release: null
+      - url: https://github.com/eclipse-score/inc_mw_com
+        latest_release: null
+      - url: https://github.com/eclipse-score/eclipse-score.github.io
+        latest_release: null
+      - url: https://github.com/eclipse-score/inc_abi_compatible_datatypes
         latest_release: null
       - url: https://github.com/eclipse-score/inc_config_management
         latest_release: null
@@ -933,13 +985,7 @@ categories:
         latest_release: null
       - url: https://github.com/eclipse-score/inc_gen_ai
         latest_release: null
-      - url: https://github.com/eclipse-score/inc_diagnostics
-        latest_release: null
       - url: https://github.com/eclipse-score/inc_ai_platform
-        latest_release: null
-      - url: https://github.com/eclipse-score/test_module_a
-        latest_release: null
-      - url: https://github.com/eclipse-score/test_module_b
         latest_release: null
       - url: https://github.com/eclipse-score/test_integration
         latest_release: null
@@ -951,11 +997,7 @@ categories:
         latest_release: null
       - url: https://github.com/eclipse-score/examples
         latest_release: null
-      - url: https://github.com/eclipse-score/operating_system
-        latest_release: null
       - url: https://github.com/eclipse-score/inc_process_test_management
-        latest_release: null
-      - url: https://github.com/eclipse-score/apt-install
         latest_release: null
       logo: S_CORE_logo.png
     - name: Eclipse Automotive API Framework
@@ -964,25 +1006,25 @@ categories:
         OEM) to contribute with building blocks to Software-defined...
       homepage_url: https://projects.eclipse.org/projects/automotive.autoapiframework
       project: Incubating
-      repo_url: https://github.com/eclipse-autoapiframework/application-framework
+      repo_url: https://github.com/eclipse-autoapiframework
       repo_urls:
       - https://github.com/eclipse-autoapiframework/application-framework
+      - https://github.com/eclipse-autoapiframework/autoapiframework
       - https://github.com/eclipse-autoapiframework/.github
       - https://github.com/eclipse-autoapiframework/vss-gui-tool
-      - https://github.com/eclipse-autoapiframework/autoapiframework
       - https://github.com/eclipse-autoapiframework/.eclipsefdn
       repositories:
       - url: https://github.com/eclipse-autoapiframework/application-framework
         latest_release:
-          tag_name: v0.6.0
-          name: v0.6.0
-          url: https://github.com/eclipse-autoapiframework/application-framework/releases/tag/v0.6.0
-          published_at: '2026-02-17T10:25:58Z'
+          tag_name: v0.7.0
+          name: v0.7.0
+          url: https://github.com/eclipse-autoapiframework/application-framework/releases/tag/v0.7.0
+          published_at: '2026-04-07T05:52:17Z'
+      - url: https://github.com/eclipse-autoapiframework/autoapiframework
+        latest_release: null
       - url: https://github.com/eclipse-autoapiframework/.github
         latest_release: null
       - url: https://github.com/eclipse-autoapiframework/vss-gui-tool
-        latest_release: null
-      - url: https://github.com/eclipse-autoapiframework/autoapiframework
         latest_release: null
       - url: https://github.com/eclipse-autoapiframework/.eclipsefdn
         latest_release: null
@@ -995,13 +1037,17 @@ categories:
         Eclipse Automotive Integration for...'
       homepage_url: https://projects.eclipse.org/projects/automotive.autosd
       project: Incubating
-      repo_url: https://github.com/eclipse-autosd/eclipse-autosd
+      repo_url: https://github.com/eclipse-autosd
       repo_urls:
       - https://github.com/eclipse-autosd/eclipse-autosd
       - https://github.com/eclipse-autosd/.eclipsefdn
       repositories:
       - url: https://github.com/eclipse-autosd/eclipse-autosd
-        latest_release: null
+        latest_release:
+          tag_name: dev
+          name: Rolling Builds
+          url: https://github.com/eclipse-autosd/eclipse-autosd/releases/tag/dev
+          published_at: '2026-04-28T08:58:12Z'
       - url: https://github.com/eclipse-autosd/.eclipsefdn
         latest_release: null
       logo: incubating.png
@@ -1011,8 +1057,13 @@ categories:
         SDV working group (sdv.eclipse.org). This makes it...
       homepage_url: https://projects.eclipse.org/projects/automotive.sdv-blueprints
       project: Incubating
-      repo_url: https://github.com/eclipse-sdv-blueprints/ros-racer
+      repo_url: https://github.com/eclipse-sdv-blueprints
       repo_urls:
+      - https://github.com/eclipse-sdv-blueprints/blueprints-website
+      - https://github.com/eclipse-sdv-blueprints/e2e-vehicle-signals
+      - https://github.com/eclipse-sdv-blueprints/insurance
+      - https://github.com/eclipse-sdv-blueprints/commercial-sdv-stack
+      - https://github.com/eclipse-sdv-blueprints/.eclipsefdn
       - https://github.com/eclipse-sdv-blueprints/ros-racer
       - https://github.com/eclipse-sdv-blueprints/service-to-signal
       - https://github.com/eclipse-sdv-blueprints/fleet-management
@@ -1020,10 +1071,17 @@ categories:
       - https://github.com/eclipse-sdv-blueprints/companion-application
       - https://github.com/eclipse-sdv-blueprints/software-orchestration
       - https://github.com/eclipse-sdv-blueprints/.github
-      - https://github.com/eclipse-sdv-blueprints/.eclipsefdn
-      - https://github.com/eclipse-sdv-blueprints/blueprints-website
-      - https://github.com/eclipse-sdv-blueprints/insurance
       repositories:
+      - url: https://github.com/eclipse-sdv-blueprints/blueprints-website
+        latest_release: null
+      - url: https://github.com/eclipse-sdv-blueprints/e2e-vehicle-signals
+        latest_release: null
+      - url: https://github.com/eclipse-sdv-blueprints/insurance
+        latest_release: null
+      - url: https://github.com/eclipse-sdv-blueprints/commercial-sdv-stack
+        latest_release: null
+      - url: https://github.com/eclipse-sdv-blueprints/.eclipsefdn
+        latest_release: null
       - url: https://github.com/eclipse-sdv-blueprints/ros-racer
         latest_release: null
       - url: https://github.com/eclipse-sdv-blueprints/service-to-signal
@@ -1037,12 +1095,6 @@ categories:
       - url: https://github.com/eclipse-sdv-blueprints/software-orchestration
         latest_release: null
       - url: https://github.com/eclipse-sdv-blueprints/.github
-        latest_release: null
-      - url: https://github.com/eclipse-sdv-blueprints/.eclipsefdn
-        latest_release: null
-      - url: https://github.com/eclipse-sdv-blueprints/blueprints-website
-        latest_release: null
-      - url: https://github.com/eclipse-sdv-blueprints/insurance
         latest_release: null
       logo: blueprints.png
 - name: RTOS
@@ -1059,93 +1111,46 @@ categories:
         ThreadX - advanced...'
       homepage_url: https://projects.eclipse.org/projects/iot.threadx
       project: Incubating
-      repo_url: https://github.com/eclipse-threadx/levelx
+      repo_url: https://github.com/eclipse-threadx
       repo_urls:
-      - https://github.com/eclipse-threadx/levelx
-      - https://github.com/eclipse-threadx/usbx
-      - https://github.com/eclipse-threadx/iot-devkit
-      - https://github.com/eclipse-threadx/filex
-      - https://github.com/eclipse-threadx/rtos-docs
-      - https://github.com/eclipse-threadx/netxduo
-      - https://github.com/eclipse-threadx/threadx
-      - https://github.com/eclipse-threadx/rtos-docs-asciidoc
-      - https://github.com/eclipse-threadx/rtos-docs-html
-      - https://github.com/eclipse-threadx/guix
-      - https://github.com/eclipse-threadx/tracex
       - https://github.com/eclipse-threadx/.eclipsefdn
-      - https://github.com/eclipse-threadx/supported-platforms
-      - https://github.com/eclipse-threadx/.github
-      - https://github.com/eclipse-threadx/samples
+      - https://github.com/eclipse-threadx/threadx
+      - https://github.com/eclipse-threadx/usbx
+      - https://github.com/eclipse-threadx/rtos-docs-asciidoc
+      - https://github.com/eclipse-threadx/samplex
       - https://github.com/eclipse-threadx/getting-started
       - https://github.com/eclipse-threadx/threadx-learn-samples
+      - https://github.com/eclipse-threadx/samples
+      - https://github.com/eclipse-threadx/guix
+      - https://github.com/eclipse-threadx/levelx
+      - https://github.com/eclipse-threadx/filex
+      - https://github.com/eclipse-threadx/netxduo
+      - https://github.com/eclipse-threadx/iot-devkit
+      - https://github.com/eclipse-threadx/rtos-docs
+      - https://github.com/eclipse-threadx/rtos-docs-html
+      - https://github.com/eclipse-threadx/tracex
+      - https://github.com/eclipse-threadx/supported-platforms
+      - https://github.com/eclipse-threadx/.github
       - https://github.com/eclipse-threadx/cmsis-packs
       repositories:
-      - url: https://github.com/eclipse-threadx/levelx
-        latest_release:
-          tag_name: v6.4.5.202504_rel
-          name: Eclipse ThreadX LevelX 6.4.5.202504
-          url: https://github.com/eclipse-threadx/levelx/releases/tag/v6.4.5.202504_rel
-          published_at: '2026-01-12T23:16:29Z'
-      - url: https://github.com/eclipse-threadx/usbx
-        latest_release:
-          tag_name: v6.4.5.202504a_rel
-          name: Eclipse ThreadX USBX 6.4.5.202504a
-          url: https://github.com/eclipse-threadx/usbx/releases/tag/v6.4.5.202504a_rel
-          published_at: '2026-01-14T16:29:09Z'
-      - url: https://github.com/eclipse-threadx/iot-devkit
-        latest_release:
-          tag_name: v1.0.0
-          name: Eclipse ThreadX IoT DevKit Starter Application v1.0.0
-          url: https://github.com/eclipse-threadx/iot-devkit/releases/tag/v1.0.0
-          published_at: '2025-09-22T11:22:09Z'
-      - url: https://github.com/eclipse-threadx/filex
-        latest_release:
-          tag_name: v6.4.5.202504_rel
-          name: Eclipse ThreadX FileX  6.4.5.202504
-          url: https://github.com/eclipse-threadx/filex/releases/tag/v6.4.5.202504_rel
-          published_at: '2026-01-12T22:53:45Z'
-      - url: https://github.com/eclipse-threadx/rtos-docs
-        latest_release: null
-      - url: https://github.com/eclipse-threadx/netxduo
-        latest_release:
-          tag_name: v6.4.5.202504_rel
-          name: Eclipse ThreadX NetX Duo 6.4.5.202504
-          url: https://github.com/eclipse-threadx/netxduo/releases/tag/v6.4.5.202504_rel
-          published_at: '2026-01-12T16:34:10Z'
-      - url: https://github.com/eclipse-threadx/threadx
-        latest_release:
-          tag_name: v6.4.5.202504_rel
-          name: Eclipse ThreadX 6.4.5.202504
-          url: https://github.com/eclipse-threadx/threadx/releases/tag/v6.4.5.202504_rel
-          published_at: '2026-01-09T15:04:12Z'
-      - url: https://github.com/eclipse-threadx/rtos-docs-asciidoc
-        latest_release: null
-      - url: https://github.com/eclipse-threadx/rtos-docs-html
-        latest_release: null
-      - url: https://github.com/eclipse-threadx/guix
-        latest_release:
-          tag_name: v6.4.5.202504_rel
-          name: Eclipse ThreadX GUIX 6.4.5.202504
-          url: https://github.com/eclipse-threadx/guix/releases/tag/v6.4.5.202504_rel
-          published_at: '2026-01-13T14:53:02Z'
-      - url: https://github.com/eclipse-threadx/tracex
-        latest_release:
-          tag_name: v6.4.1_rel
-          name: Eclipse ThreadX TraceX 6.4.1
-          url: https://github.com/eclipse-threadx/tracex/releases/tag/v6.4.1_rel
-          published_at: '2024-02-29T02:11:44Z'
       - url: https://github.com/eclipse-threadx/.eclipsefdn
         latest_release: null
-      - url: https://github.com/eclipse-threadx/supported-platforms
-        latest_release: null
-      - url: https://github.com/eclipse-threadx/.github
-        latest_release: null
-      - url: https://github.com/eclipse-threadx/samples
+      - url: https://github.com/eclipse-threadx/threadx
         latest_release:
-          tag_name: v6.4_tsn
-          name: Azure RTOS 6.4 TSN Project
-          url: https://github.com/eclipse-threadx/samples/releases/tag/v6.4_tsn
-          published_at: '2024-01-23T01:46:27Z'
+          tag_name: v6.5.0.202601_rel
+          name: Eclipse ThreadX v6.5.0.202601
+          url: https://github.com/eclipse-threadx/threadx/releases/tag/v6.5.0.202601_rel
+          published_at: '2026-03-06T23:26:19Z'
+      - url: https://github.com/eclipse-threadx/usbx
+        latest_release:
+          tag_name: v6.5.0.202601_rel
+          name: Eclipse ThreadX USBX v.6.5.0.202601
+          url: https://github.com/eclipse-threadx/usbx/releases/tag/v6.5.0.202601_rel
+          published_at: '2026-03-06T23:26:31Z'
+      - url: https://github.com/eclipse-threadx/rtos-docs-asciidoc
+        latest_release: null
+      - url: https://github.com/eclipse-threadx/samplex
+        latest_release: null
       - url: https://github.com/eclipse-threadx/getting-started
         latest_release:
           tag_name: azrtos_v6.2.0
@@ -1158,6 +1163,56 @@ categories:
           name: vs
           url: https://github.com/eclipse-threadx/threadx-learn-samples/releases/tag/vs
           published_at: null
+      - url: https://github.com/eclipse-threadx/samples
+        latest_release:
+          tag_name: v6.4_tsn
+          name: Azure RTOS 6.4 TSN Project
+          url: https://github.com/eclipse-threadx/samples/releases/tag/v6.4_tsn
+          published_at: '2024-01-23T01:46:27Z'
+      - url: https://github.com/eclipse-threadx/guix
+        latest_release:
+          tag_name: v6.5.0.202601_rel
+          name: Eclipse ThreadX GUIX v6.5.0.202601
+          url: https://github.com/eclipse-threadx/guix/releases/tag/v6.5.0.202601_rel
+          published_at: '2026-03-06T23:26:46Z'
+      - url: https://github.com/eclipse-threadx/levelx
+        latest_release:
+          tag_name: v6.5.0.202601_rel
+          name: Eclipse ThreadX LevelX v6.5.0.202601
+          url: https://github.com/eclipse-threadx/levelx/releases/tag/v6.5.0.202601_rel
+          published_at: '2026-03-06T23:26:41Z'
+      - url: https://github.com/eclipse-threadx/filex
+        latest_release:
+          tag_name: v6.5.0.202601_rel
+          name: Eclipse ThreadX FileX v6.5.0.202601
+          url: https://github.com/eclipse-threadx/filex/releases/tag/v6.5.0.202601_rel
+          published_at: '2026-03-06T23:26:35Z'
+      - url: https://github.com/eclipse-threadx/netxduo
+        latest_release:
+          tag_name: v6.5.0.202601_rel
+          name: Eclipse ThreadX NetX Duo 6.5.0.202601
+          url: https://github.com/eclipse-threadx/netxduo/releases/tag/v6.5.0.202601_rel
+          published_at: '2026-03-06T23:26:24Z'
+      - url: https://github.com/eclipse-threadx/iot-devkit
+        latest_release:
+          tag_name: v1.0.1
+          name: Eclipse ThreadX IoT DevKit Starter Application v1.0.1
+          url: https://github.com/eclipse-threadx/iot-devkit/releases/tag/v1.0.1
+          published_at: '2026-03-09T15:43:53Z'
+      - url: https://github.com/eclipse-threadx/rtos-docs
+        latest_release: null
+      - url: https://github.com/eclipse-threadx/rtos-docs-html
+        latest_release: null
+      - url: https://github.com/eclipse-threadx/tracex
+        latest_release:
+          tag_name: v6.4.1_rel
+          name: Eclipse ThreadX TraceX 6.4.1
+          url: https://github.com/eclipse-threadx/tracex/releases/tag/v6.4.1_rel
+          published_at: '2024-02-29T02:11:44Z'
+      - url: https://github.com/eclipse-threadx/supported-platforms
+        latest_release: null
+      - url: https://github.com/eclipse-threadx/.github
+        latest_release: null
       - url: https://github.com/eclipse-threadx/cmsis-packs
         latest_release: null
       logo: ThreadX-Color-portrait.png
@@ -1178,16 +1233,16 @@ categories:
         can be used  to introspect, monitor and manipulate the...
       homepage_url: https://projects.eclipse.org/projects/automotive.muto
       project: Incubating
-      repo_url: https://github.com/eclipse-muto/muto
+      repo_url: https://github.com/eclipse-muto
       repo_urls:
-      - https://github.com/eclipse-muto/muto
       - https://github.com/eclipse-muto/composer
       - https://github.com/eclipse-muto/agent
-      - https://github.com/eclipse-muto/.github
+      - https://github.com/eclipse-muto/muto
+      - https://github.com/eclipse-muto/core
       - https://github.com/eclipse-muto/messages
+      - https://github.com/eclipse-muto/.github
       - https://github.com/eclipse-muto/.eclipsefdn
       - https://github.com/eclipse-muto/docs
-      - https://github.com/eclipse-muto/core
       - https://github.com/eclipse-muto/dashboard-device
       - https://github.com/eclipse-muto/liveui
       - https://github.com/eclipse-muto/liveui-react-native
@@ -1198,21 +1253,21 @@ categories:
       - https://github.com/eclipse-muto/liveui-vue
       - https://github.com/eclipse-muto/liveui-samples
       repositories:
-      - url: https://github.com/eclipse-muto/muto
-        latest_release: *id001
       - url: https://github.com/eclipse-muto/composer
         latest_release: null
       - url: https://github.com/eclipse-muto/agent
         latest_release: null
-      - url: https://github.com/eclipse-muto/.github
+      - url: https://github.com/eclipse-muto/muto
+        latest_release: *id001
+      - url: https://github.com/eclipse-muto/core
         latest_release: null
       - url: https://github.com/eclipse-muto/messages
+        latest_release: null
+      - url: https://github.com/eclipse-muto/.github
         latest_release: null
       - url: https://github.com/eclipse-muto/.eclipsefdn
         latest_release: null
       - url: https://github.com/eclipse-muto/docs
-        latest_release: null
-      - url: https://github.com/eclipse-muto/core
         latest_release: null
       - url: https://github.com/eclipse-muto/dashboard-device
         latest_release: null
@@ -1266,7 +1321,7 @@ categories:
         Publish...'
       homepage_url: https://projects.eclipse.org/projects/automotive.p3com
       project: Incubating
-      repo_url: https://github.com/eclipse-p3com/.github
+      repo_url: https://github.com/eclipse-p3com
       repo_urls:
       - https://github.com/eclipse-p3com/.github
       - https://github.com/eclipse-p3com/.eclipsefdn
@@ -1285,16 +1340,16 @@ categories:
         on a single computer node or between different nodes...
       homepage_url: https://projects.eclipse.org/projects/automotive.ecal
       project: Incubating
-      repo_url: https://github.com/eclipse-ecal/ecal
+      repo_url: https://github.com/eclipse-ecal
       repo_urls:
-      - https://github.com/eclipse-ecal/ecal
       - https://github.com/eclipse-ecal/ecal-test-suite
+      - https://github.com/eclipse-ecal/ecal
       - https://github.com/eclipse-ecal/rustecal
       - https://github.com/eclipse-ecal/fineftp-server
+      - https://github.com/eclipse-ecal/tcp_pubsub
       - https://github.com/eclipse-ecal/ecal-foxglove-bridge
       - https://github.com/eclipse-ecal/ecaludp
       - https://github.com/eclipse-ecal/udpcap
-      - https://github.com/eclipse-ecal/tcp_pubsub
       - https://github.com/eclipse-ecal/ecal-mcap-tools
       - https://github.com/eclipse-ecal/.eclipsefdn
       - https://github.com/eclipse-ecal/ecal-rs
@@ -1311,22 +1366,32 @@ categories:
       - https://github.com/eclipse-ecal/ecal-mqtt-bridge
       - https://github.com/eclipse-ecal/ecal-utils
       repositories:
-      - url: https://github.com/eclipse-ecal/ecal
-        latest_release:
-          tag_name: v6.1.0-rc.2
-          name: ' v6.1.0-rc.2'
-          url: https://github.com/eclipse-ecal/ecal/releases/tag/v6.1.0-rc.2
-          published_at: '2026-02-09T13:47:19Z'
       - url: https://github.com/eclipse-ecal/ecal-test-suite
         latest_release: null
+      - url: https://github.com/eclipse-ecal/ecal
+        latest_release:
+          tag_name: v6.1.1
+          name: v6.1.1
+          url: https://github.com/eclipse-ecal/ecal/releases/tag/v6.1.1
+          published_at: '2026-04-02T06:57:20Z'
       - url: https://github.com/eclipse-ecal/rustecal
-        latest_release: null
+        latest_release:
+          tag_name: v0.1.9
+          name: v0.1.9
+          url: https://github.com/eclipse-ecal/rustecal/releases/tag/v0.1.9
+          published_at: null
       - url: https://github.com/eclipse-ecal/fineftp-server
         latest_release:
-          tag_name: v1.5.1
-          name: v1.5.1
-          url: https://github.com/eclipse-ecal/fineftp-server/releases/tag/v1.5.1
-          published_at: '2025-04-03T12:46:45Z'
+          tag_name: v1.6.0
+          name: ' fineFTP v1.6.0'
+          url: https://github.com/eclipse-ecal/fineftp-server/releases/tag/v1.6.0
+          published_at: '2026-03-26T15:10:17Z'
+      - url: https://github.com/eclipse-ecal/tcp_pubsub
+        latest_release:
+          tag_name: v2.0.1
+          name: tcp_pubsub v2.0.1
+          url: https://github.com/eclipse-ecal/tcp_pubsub/releases/tag/v2.0.1
+          published_at: '2025-04-09T14:10:10Z'
       - url: https://github.com/eclipse-ecal/ecal-foxglove-bridge
         latest_release:
           tag_name: v0.2.0
@@ -1345,12 +1410,6 @@ categories:
           name: v2.0.4
           url: https://github.com/eclipse-ecal/udpcap/releases/tag/v2.0.4
           published_at: '2025-05-15T10:57:05Z'
-      - url: https://github.com/eclipse-ecal/tcp_pubsub
-        latest_release:
-          tag_name: v2.0.1
-          name: tcp_pubsub v2.0.1
-          url: https://github.com/eclipse-ecal/tcp_pubsub/releases/tag/v2.0.1
-          published_at: '2025-04-09T14:10:10Z'
       - url: https://github.com/eclipse-ecal/ecal-mcap-tools
         latest_release: null
       - url: https://github.com/eclipse-ecal/.eclipsefdn
@@ -1403,28 +1462,27 @@ categories:
         latest_release: null
       logo: ecal_square.png
     - name: Eclipse Kuksa
-      description: 'The open Eclipse KUKSA™ project aims to provide shared building
-        blocks for the Software Defined Vehicles that can be shared across the industry.
-
-        A modern car contains more than 200 millions lines of...'
+      description: Eclipse KUKSA provides the essential data orchestration layer for
+        the modern Software Defined Vehicle (SDV) ecosystem. It acts as the "connective
+        tissue" between a vehicle’s complex hardware sensors...
       homepage_url: https://projects.eclipse.org/projects/automotive.kuksa
       project: Incubating
-      repo_url: https://github.com/eclipse/kuksa.val
+      repo_url: https://github.com/eclipse-kuksa
       repo_urls:
-      - https://github.com/eclipse/kuksa.val
+      - https://github.com/eclipse-kuksa/kuksa-incubation
       - https://github.com/eclipse-kuksa/kuksa-databroker
-      - https://github.com/eclipse-kuksa/kuksa-python-sdk
       - https://github.com/eclipse-kuksa/kuksa-common
-      - https://github.com/eclipse-kuksa/kuksa-mock-provider
-      - https://github.com/eclipse-kuksa/kuksa-can-provider
-      - https://github.com/eclipse-kuksa/kuksa-perf
       - https://github.com/eclipse-kuksa/kuksa-rust-sdk
+      - https://github.com/eclipse-kuksa/kuksa-perf
+      - https://github.com/eclipse-kuksa/kuksa-actions
+      - https://github.com/eclipse-kuksa/.github
+      - https://github.com/eclipse-kuksa/.eclipsefdn
+      - https://github.com/eclipse-kuksa/kuksa-viss
+      - https://github.com/eclipse-kuksa/kuksa-can-provider
+      - https://github.com/eclipse-kuksa/kuksa-python-sdk
+      - https://github.com/eclipse-kuksa/kuksa-mock-provider
       - https://github.com/eclipse-kuksa/kuksa-java-sdk
       - https://github.com/eclipse-kuksa/kuksa-android-sdk
-      - https://github.com/eclipse-kuksa/kuksa-incubation
-      - https://github.com/eclipse-kuksa/.eclipsefdn
-      - https://github.com/eclipse-kuksa/.github
-      - https://github.com/eclipse-kuksa/kuksa-actions
       - https://github.com/eclipse-kuksa/kuksa-csv-provider
       - https://github.com/eclipse-kuksa/kuksa-proto
       - https://github.com/eclipse-kuksa/kuksa-website
@@ -1434,36 +1492,65 @@ categories:
       - https://github.com/eclipse-kuksa/kuksa.val.feeders
       - https://github.com/eclipse-kuksa/kuksa.val.services
       - https://github.com/eclipse-kuksa/kuksa-hardware
-      - https://github.com/eclipse-kuksa/kuksa-viss
       - https://github.com/eclipse-kuksa/kuksa-dds-provider
       - https://github.com/eclipse-kuksa/kuksa.cloud
       - https://github.com/eclipse-kuksa/kuksa.apps
       - https://github.com/eclipse-kuksa/kuksa.ide
       - https://github.com/eclipse-kuksa/kuksa.invehicle
       repositories:
-      - url: https://github.com/eclipse/kuksa.val
+      - url: https://github.com/eclipse-kuksa/kuksa-incubation
         latest_release:
-          tag_name: 0.4.1
-          name: KUKSA.val 0.4.1 Release
-          url: https://github.com/eclipse-archived/kuksa.val/releases/tag/0.4.1
-          published_at: '2023-10-31T10:00:29Z'
+          tag_name: 0.4.0
+          name: Kuksa Incubation 0.4.0
+          url: https://github.com/eclipse-kuksa/kuksa-incubation/releases/tag/0.4.0
+          published_at: '2024-03-08T10:17:00Z'
       - url: https://github.com/eclipse-kuksa/kuksa-databroker
         latest_release:
-          tag_name: 0.6.0
-          name: KUKSA Databroker 0.6.0
-          url: https://github.com/eclipse-kuksa/kuksa-databroker/releases/tag/0.6.0
-          published_at: '2025-09-24T14:27:27Z'
-      - url: https://github.com/eclipse-kuksa/kuksa-python-sdk
-        latest_release:
-          tag_name: 0.5.0
-          name: KUKSA Python SDK 0.5.0
-          url: https://github.com/eclipse-kuksa/kuksa-python-sdk/releases/tag/0.5.0
-          published_at: '2025-08-28T06:54:58Z'
+          tag_name: 0.6.1
+          name: KUKSA Databroker 0.6.1
+          url: https://github.com/eclipse-kuksa/kuksa-databroker/releases/tag/0.6.1
+          published_at: '2026-04-01T09:56:50Z'
       - url: https://github.com/eclipse-kuksa/kuksa-common
         latest_release:
           tag_name: v1.0
           name: v1.0
           url: https://github.com/eclipse-kuksa/kuksa-common/releases/tag/v1.0
+          published_at: null
+      - url: https://github.com/eclipse-kuksa/kuksa-rust-sdk
+        latest_release:
+          tag_name: 0.2.2
+          name: KUKSA Rust SDK 0.2.2
+          url: https://github.com/eclipse-kuksa/kuksa-rust-sdk/releases/tag/0.2.2
+          published_at: '2026-04-01T15:34:51Z'
+      - url: https://github.com/eclipse-kuksa/kuksa-perf
+        latest_release:
+          tag_name: 0.3.2
+          name: Eclipse Kuksa databroker-perf 0.3.2
+          url: https://github.com/eclipse-kuksa/kuksa-perf/releases/tag/0.3.2
+          published_at: '2024-12-12T10:08:40Z'
+      - url: https://github.com/eclipse-kuksa/kuksa-actions
+        latest_release:
+          tag_name: '5.0'
+          name: '5.0'
+          url: https://github.com/eclipse-kuksa/kuksa-actions/releases/tag/5.0
+          published_at: null
+      - url: https://github.com/eclipse-kuksa/.github
+        latest_release: null
+      - url: https://github.com/eclipse-kuksa/.eclipsefdn
+        latest_release: null
+      - url: https://github.com/eclipse-kuksa/kuksa-viss
+        latest_release: null
+      - url: https://github.com/eclipse-kuksa/kuksa-can-provider
+        latest_release:
+          tag_name: 0.4.3
+          name: KUKSA CAN Provider 0.4.3 Release
+          url: https://github.com/eclipse-kuksa/kuksa-can-provider/releases/tag/0.4.3
+          published_at: '2024-05-06T09:07:38Z'
+      - url: https://github.com/eclipse-kuksa/kuksa-python-sdk
+        latest_release:
+          tag_name: 0.5.1-a2
+          name: KUKSA Python SDK 0.5.1-a2
+          url: https://github.com/eclipse-kuksa/kuksa-python-sdk/releases/tag/untagged-1b22173b301e02afdf0c
           published_at: null
       - url: https://github.com/eclipse-kuksa/kuksa-mock-provider
         latest_release:
@@ -1471,24 +1558,6 @@ categories:
           name: KUKSA Mock Provider 0.4.1 Release
           url: https://github.com/eclipse-kuksa/kuksa-mock-provider/releases/tag/0.4.1
           published_at: '2024-11-27T10:26:15Z'
-      - url: https://github.com/eclipse-kuksa/kuksa-can-provider
-        latest_release:
-          tag_name: 0.4.3
-          name: KUKSA CAN Provider 0.4.3 Release
-          url: https://github.com/eclipse-kuksa/kuksa-can-provider/releases/tag/0.4.3
-          published_at: '2024-05-06T09:07:38Z'
-      - url: https://github.com/eclipse-kuksa/kuksa-perf
-        latest_release:
-          tag_name: 0.3.2
-          name: Eclipse Kuksa databroker-perf 0.3.2
-          url: https://github.com/eclipse-kuksa/kuksa-perf/releases/tag/0.3.2
-          published_at: '2024-12-12T10:08:40Z'
-      - url: https://github.com/eclipse-kuksa/kuksa-rust-sdk
-        latest_release:
-          tag_name: 0.2.1
-          name: KUKSA Rust SDK 0.2.1
-          url: https://github.com/eclipse-kuksa/kuksa-rust-sdk/releases/tag/0.2.1
-          published_at: '2025-08-06T13:15:14Z'
       - url: https://github.com/eclipse-kuksa/kuksa-java-sdk
         latest_release:
           tag_name: release/v0.4.0
@@ -1501,22 +1570,6 @@ categories:
           name: release/v0.2.1
           url: https://github.com/eclipse-kuksa/kuksa-android-sdk/releases/tag/release/v0.2.1
           published_at: '2024-03-26T06:47:02Z'
-      - url: https://github.com/eclipse-kuksa/kuksa-incubation
-        latest_release:
-          tag_name: 0.4.0
-          name: Kuksa Incubation 0.4.0
-          url: https://github.com/eclipse-kuksa/kuksa-incubation/releases/tag/0.4.0
-          published_at: '2024-03-08T10:17:00Z'
-      - url: https://github.com/eclipse-kuksa/.eclipsefdn
-        latest_release: null
-      - url: https://github.com/eclipse-kuksa/.github
-        latest_release: null
-      - url: https://github.com/eclipse-kuksa/kuksa-actions
-        latest_release:
-          tag_name: '4.8'
-          name: '4.8'
-          url: https://github.com/eclipse-kuksa/kuksa-actions/releases/tag/4.8
-          published_at: null
       - url: https://github.com/eclipse-kuksa/kuksa-csv-provider
         latest_release:
           tag_name: 0.4.5
@@ -1567,8 +1620,6 @@ categories:
           name: hardware2_v11
           url: https://github.com/eclipse-kuksa/kuksa-hardware/releases/tag/hardware2_v11
           published_at: null
-      - url: https://github.com/eclipse-kuksa/kuksa-viss
-        latest_release: null
       - url: https://github.com/eclipse-kuksa/kuksa-dds-provider
         latest_release:
           tag_name: 0.4.3
@@ -1606,7 +1657,7 @@ categories:
         layer that allows modern application...
       homepage_url: https://projects.eclipse.org/projects/automotive.chariott
       project: Incubating
-      repo_url: https://github.com/eclipse-chariott/chariott
+      repo_url: https://github.com/eclipse-chariott
       repo_urls:
       - https://github.com/eclipse-chariott/chariott
       - https://github.com/eclipse-chariott/chariott-example-applications
@@ -1639,17 +1690,19 @@ categories:
         with low duty-cycle by allowing the negotiation of data...
       homepage_url: https://projects.eclipse.org/projects/iot.zenoh
       project: Incubating
-      repo_url: https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds
+      repo_url: https://github.com/eclipse-zenoh
       repo_urls:
-      - https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds
       - https://github.com/eclipse-zenoh/zenoh
-      - https://github.com/eclipse-zenoh/zenoh-plugin-dds
-      - https://github.com/eclipse-zenoh/zenoh-plugin-mqtt
-      - https://github.com/eclipse-zenoh/zenoh-plugin-webserver
-      - https://github.com/eclipse-zenoh/zenoh-pico
+      - https://github.com/eclipse-zenoh/zenoh-demos
+      - https://github.com/eclipse-zenoh/zenoh-java
       - https://github.com/eclipse-zenoh/zenoh-python
       - https://github.com/eclipse-zenoh/zenoh-cpp
       - https://github.com/eclipse-zenoh/zenoh-ts
+      - https://github.com/eclipse-zenoh/zenoh-pico
+      - https://github.com/eclipse-zenoh/zenoh-plugin-mqtt
+      - https://github.com/eclipse-zenoh/zenoh-plugin-webserver
+      - https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds
+      - https://github.com/eclipse-zenoh/zenoh-plugin-dds
       - https://github.com/eclipse-zenoh/zenoh-backend-filesystem
       - https://github.com/eclipse-zenoh/zenoh-c
       - https://github.com/eclipse-zenoh/zenoh-backend-rocksdb
@@ -1657,122 +1710,141 @@ categories:
       - https://github.com/eclipse-zenoh/zenoh-kotlin
       - https://github.com/eclipse-zenoh/zenoh-backend-influxdb
       - https://github.com/eclipse-zenoh/zenoh-backend-s3
-      - https://github.com/eclipse-zenoh/zenoh-java
-      - https://github.com/eclipse-zenoh/ci
-      - https://github.com/eclipse-zenoh/zenoh-plugin-ros1
-      - https://github.com/eclipse-zenoh/homebrew-zenoh
-      - https://github.com/eclipse-zenoh/zenoh-csharp
-      - https://github.com/eclipse-zenoh/zenoh-go
+      - https://github.com/eclipse-zenoh/zenoh-nostd
       - https://github.com/eclipse-zenoh/roadmap
-      - https://github.com/eclipse-zenoh/zenoh-demos
+      - https://github.com/eclipse-zenoh/ci
+      - https://github.com/eclipse-zenoh/homebrew-zenoh
+      - https://github.com/eclipse-zenoh/zenoh-go
       - https://github.com/eclipse-zenoh/.eclipsefdn
+      - https://github.com/eclipse-zenoh/zenoh-plugin-ros1
+      - https://github.com/eclipse-zenoh/zenoh-csharp
       - https://github.com/eclipse-zenoh/.github
       - https://github.com/eclipse-zenoh/zenoh-plugin-zenoh-flow
       - https://github.com/eclipse-zenoh/zenoh-backend-sql
       repositories:
-      - url: https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/releases/tag/1.7.2
-          published_at: '2026-01-08T17:41:41Z'
       - url: https://github.com/eclipse-zenoh/zenoh
         latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh/releases/tag/1.7.2
-          published_at: '2026-01-08T16:18:27Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-plugin-dds
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh/releases/tag/1.9.0
+          published_at: '2026-04-10T11:57:54Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-demos
         latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-plugin-dds/releases/tag/1.7.2
-          published_at: '2026-01-08T17:41:49Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-plugin-mqtt
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-plugin-mqtt/releases/tag/1.7.2
-          published_at: '2026-01-08T17:42:00Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-plugin-webserver
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-plugin-webserver/releases/tag/1.7.2
-          published_at: '2026-01-08T17:37:59Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-pico
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-pico/releases/tag/1.7.2
-          published_at: '2026-01-08T17:01:09Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-python
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-python/releases/tag/1.7.2
-          published_at: '2026-01-08T17:42:00Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-cpp
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-cpp/releases/tag/1.7.2
-          published_at: '2026-01-08T19:23:37Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-ts
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-ts/releases/tag/1.7.2
-          published_at: '2026-01-08T17:45:58Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-backend-filesystem
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-backend-filesystem/releases/tag/1.7.2
-          published_at: '2026-01-08T17:53:57Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-c
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-c/releases/tag/1.7.2
-          published_at: '2026-01-08T19:13:50Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-backend-rocksdb
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-backend-rocksdb/releases/tag/1.7.2
-          published_at: '2026-01-08T17:51:59Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-dissector
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-dissector/releases/tag/1.7.2
-          published_at: '2026-01-09T09:37:50Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-kotlin
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-kotlin/releases/tag/1.7.2
-          published_at: '2026-01-08T17:50:22Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-backend-influxdb
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-backend-influxdb/releases/tag/1.7.2
-          published_at: '2026-01-08T17:38:50Z'
-      - url: https://github.com/eclipse-zenoh/zenoh-backend-s3
-        latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-backend-s3/releases/tag/1.7.2
-          published_at: '2026-01-08T17:40:17Z'
+          tag_name: zenoh-flow-v0.3.0
+          name: zenoh-flow-v0.3.0
+          url: https://github.com/eclipse-zenoh/zenoh-demos/releases/tag/zenoh-flow-v0.3.0
+          published_at: null
       - url: https://github.com/eclipse-zenoh/zenoh-java
         latest_release:
-          tag_name: 1.7.2
-          name: 1.7.2
-          url: https://github.com/eclipse-zenoh/zenoh-java/releases/tag/1.7.2
-          published_at: '2026-01-08T17:49:54Z'
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-java/releases/tag/1.9.0
+          published_at: '2026-04-10T13:31:21Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-python
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-python/releases/tag/1.9.0
+          published_at: '2026-04-10T13:23:01Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-cpp
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-cpp/releases/tag/1.9.0
+          published_at: '2026-04-13T09:17:45Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-ts
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-ts/releases/tag/1.9.0
+          published_at: '2026-04-10T13:29:04Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-pico
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-pico/releases/tag/1.9.0
+          published_at: '2026-04-13T07:26:16Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-plugin-mqtt
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-plugin-mqtt/releases/tag/1.9.0
+          published_at: '2026-04-10T13:25:23Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-plugin-webserver
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-plugin-webserver/releases/tag/1.9.0
+          published_at: '2026-04-10T13:20:27Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/releases/tag/1.9.0
+          published_at: '2026-04-10T13:25:42Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-plugin-dds
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-plugin-dds/releases/tag/1.9.0
+          published_at: '2026-04-10T13:24:59Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-backend-filesystem
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-backend-filesystem/releases/tag/1.9.0
+          published_at: '2026-04-10T13:35:35Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-c
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-c/releases/tag/1.9.0
+          published_at: '2026-04-13T09:13:59Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-backend-rocksdb
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-backend-rocksdb/releases/tag/1.9.0
+          published_at: '2026-04-10T13:35:30Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-dissector
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-dissector/releases/tag/1.9.0
+          published_at: '2026-04-10T13:28:57Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-kotlin
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-kotlin/releases/tag/1.9.0
+          published_at: '2026-04-10T13:31:55Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-backend-influxdb
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-backend-influxdb/releases/tag/1.9.0
+          published_at: '2026-04-10T13:21:57Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-backend-s3
+        latest_release:
+          tag_name: 1.9.0
+          name: 1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-backend-s3/releases/tag/1.9.0
+          published_at: '2026-04-10T13:24:20Z'
+      - url: https://github.com/eclipse-zenoh/zenoh-nostd
+        latest_release: null
+      - url: https://github.com/eclipse-zenoh/roadmap
+        latest_release: null
       - url: https://github.com/eclipse-zenoh/ci
+        latest_release: null
+      - url: https://github.com/eclipse-zenoh/homebrew-zenoh
+        latest_release: null
+      - url: https://github.com/eclipse-zenoh/zenoh-go
+        latest_release:
+          tag_name: v1.9.0
+          name: v1.9.0
+          url: https://github.com/eclipse-zenoh/zenoh-go/releases/tag/v1.9.0
+          published_at: '2026-04-13T09:18:08Z'
+      - url: https://github.com/eclipse-zenoh/.eclipsefdn
         latest_release: null
       - url: https://github.com/eclipse-zenoh/zenoh-plugin-ros1
         latest_release:
@@ -1780,30 +1852,12 @@ categories:
           name: 1.0.0-beta.2
           url: https://github.com/eclipse-zenoh/zenoh-plugin-ros1/releases/tag/1.0.0-beta.2
           published_at: '2024-09-13T17:07:06Z'
-      - url: https://github.com/eclipse-zenoh/homebrew-zenoh
-        latest_release: null
       - url: https://github.com/eclipse-zenoh/zenoh-csharp
         latest_release:
           tag_name: 0.0.4
           name: 0.0.4
           url: https://github.com/eclipse-zenoh/zenoh-csharp/releases/tag/0.0.4
           published_at: null
-      - url: https://github.com/eclipse-zenoh/zenoh-go
-        latest_release:
-          tag_name: 0.4.2-M1
-          name: 0.4.2-M1
-          url: https://github.com/eclipse-zenoh/zenoh-go/releases/tag/0.4.2-M1
-          published_at: null
-      - url: https://github.com/eclipse-zenoh/roadmap
-        latest_release: null
-      - url: https://github.com/eclipse-zenoh/zenoh-demos
-        latest_release:
-          tag_name: zenoh-flow-v0.3.0
-          name: zenoh-flow-v0.3.0
-          url: https://github.com/eclipse-zenoh/zenoh-demos/releases/tag/zenoh-flow-v0.3.0
-          published_at: null
-      - url: https://github.com/eclipse-zenoh/.eclipsefdn
-        latest_release: null
       - url: https://github.com/eclipse-zenoh/.github
         latest_release: null
       - url: https://github.com/eclipse-zenoh/zenoh-plugin-zenoh-flow
@@ -1819,17 +1873,17 @@ categories:
         cryptographic services...'
       homepage_url: https://projects.eclipse.org/projects/automotive.heimlig
       project: Incubating
-      repo_url: https://github.com/eclipse-heimlig/heimlig
+      repo_url: https://github.com/eclipse-heimlig
       repo_urls:
+      - https://github.com/eclipse-heimlig/.eclipsefdn
       - https://github.com/eclipse-heimlig/heimlig
       - https://github.com/eclipse-heimlig/.github
-      - https://github.com/eclipse-heimlig/.eclipsefdn
       repositories:
+      - url: https://github.com/eclipse-heimlig/.eclipsefdn
+        latest_release: null
       - url: https://github.com/eclipse-heimlig/heimlig
         latest_release: null
       - url: https://github.com/eclipse-heimlig/.github
-        latest_release: null
-      - url: https://github.com/eclipse-heimlig/.eclipsefdn
         latest_release: null
       logo: incubating.png
   - name: Communication Protocols
@@ -1840,7 +1894,7 @@ categories:
         on the automotive industry. Eclipse CANought provides...
       homepage_url: https://projects.eclipse.org/projects/iot.kanto.canought
       project: Incubating
-      repo_url: https://github.com/eclipse-canought/up-cpp-server
+      repo_url: https://github.com/eclipse-canought
       repo_urls:
       - https://github.com/eclipse-canought/up-cpp-server
       - https://github.com/eclipse-canought/.github
@@ -1871,14 +1925,14 @@ categories:
         are actually different processes on a POSIX based...
       homepage_url: https://projects.eclipse.org/projects/technology.iceoryx
       project: Regular
-      repo_url: https://github.com/eclipse-iceoryx/iceoryx2
+      repo_url: https://github.com/eclipse-iceoryx
       repo_urls:
       - https://github.com/eclipse-iceoryx/iceoryx2
-      - https://github.com/eclipse-iceoryx/.eclipsefdn
-      - https://github.com/eclipse-iceoryx/iceoryx2-csharp
       - https://github.com/eclipse-iceoryx/meta-iceoryx2
       - https://github.com/eclipse-iceoryx/iceoryx
+      - https://github.com/eclipse-iceoryx/iceoryx2-csharp
       - https://github.com/eclipse-iceoryx/iceoryx-web
+      - https://github.com/eclipse-iceoryx/.eclipsefdn
       - https://github.com/eclipse-iceoryx/iceoryx-gateway-dds
       - https://github.com/eclipse-iceoryx/.github
       - https://github.com/eclipse-iceoryx/iceoryx-project-template
@@ -1891,10 +1945,6 @@ categories:
           name: v0.8.1
           url: https://github.com/eclipse-iceoryx/iceoryx2/releases/tag/v0.8.1
           published_at: '2026-01-15T14:07:45Z'
-      - url: https://github.com/eclipse-iceoryx/.eclipsefdn
-        latest_release: null
-      - url: https://github.com/eclipse-iceoryx/iceoryx2-csharp
-        latest_release: null
       - url: https://github.com/eclipse-iceoryx/meta-iceoryx2
         latest_release:
           tag_name: v0.8.1
@@ -1907,7 +1957,11 @@ categories:
           name: v2.0.6
           url: https://github.com/eclipse-iceoryx/iceoryx/releases/tag/v2.0.6
           published_at: '2024-04-26T13:41:57Z'
+      - url: https://github.com/eclipse-iceoryx/iceoryx2-csharp
+        latest_release: null
       - url: https://github.com/eclipse-iceoryx/iceoryx-web
+        latest_release: null
+      - url: https://github.com/eclipse-iceoryx/.eclipsefdn
         latest_release: null
       - url: https://github.com/eclipse-iceoryx/iceoryx-gateway-dds
         latest_release: null
@@ -1932,26 +1986,26 @@ categories:
         charging station, etc...) agnostic, leveraging well...
       homepage_url: https://projects.eclipse.org/projects/automotive.uprotocol
       project: Incubating
-      repo_url: https://github.com/eclipse-uprotocol/up-streamer-rust
+      repo_url: https://github.com/eclipse-uprotocol
       repo_urls:
+      - https://github.com/eclipse-uprotocol/ci-cd
+      - https://github.com/eclipse-uprotocol/up-transport-zenoh-rust
+      - https://github.com/eclipse-uprotocol/up-rust
+      - https://github.com/eclipse-uprotocol/up-transport-mqtt5-rust
+      - https://github.com/eclipse-uprotocol/.eclipsefdn
       - https://github.com/eclipse-uprotocol/up-streamer-rust
       - https://github.com/eclipse-uprotocol/up-spec
       - https://github.com/eclipse-uprotocol/up-rust-py
-      - https://github.com/eclipse-uprotocol/.eclipsefdn
-      - https://github.com/eclipse-uprotocol/up-rust
-      - https://github.com/eclipse-uprotocol/up-transport-mqtt5-rust
       - https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust
       - https://github.com/eclipse-uprotocol/up-subscription-rust
       - https://github.com/eclipse-uprotocol/up-zenoh-example-cpp
       - https://github.com/eclipse-uprotocol/up-cpp
       - https://github.com/eclipse-uprotocol/symphony-target-example-rust
-      - https://github.com/eclipse-uprotocol/up-transport-zenoh-rust
       - https://github.com/eclipse-uprotocol/up-transport-iceoryx2-rust
       - https://github.com/eclipse-uprotocol/up-java
       - https://github.com/eclipse-uprotocol/up-transport-mqtt5-java
       - https://github.com/eclipse-uprotocol/up-transport-zenoh-cpp
       - https://github.com/eclipse-uprotocol/up-python
-      - https://github.com/eclipse-uprotocol/ci-cd
       - https://github.com/eclipse-uprotocol/up-conan-recipes
       - https://github.com/eclipse-uprotocol/eclipse-uprotocol.github.io
       - https://github.com/eclipse-uprotocol/.github
@@ -1984,6 +2038,28 @@ categories:
       - https://github.com/eclipse-uprotocol/up-transport-azure-java
       - https://github.com/eclipse-uprotocol/up-experiments
       repositories:
+      - url: https://github.com/eclipse-uprotocol/ci-cd
+        latest_release: null
+      - url: https://github.com/eclipse-uprotocol/up-transport-zenoh-rust
+        latest_release:
+          tag_name: v0.9.0
+          name: v0.9.0
+          url: https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/releases/tag/v0.9.0
+          published_at: '2025-11-13T06:43:22Z'
+      - url: https://github.com/eclipse-uprotocol/up-rust
+        latest_release:
+          tag_name: v0.9.0
+          name: v0.9.0
+          url: https://github.com/eclipse-uprotocol/up-rust/releases/tag/v0.9.0
+          published_at: '2025-11-12T13:58:02Z'
+      - url: https://github.com/eclipse-uprotocol/up-transport-mqtt5-rust
+        latest_release:
+          tag_name: v0.4.0
+          name: v0.4.0
+          url: https://github.com/eclipse-uprotocol/up-transport-mqtt5-rust/releases/tag/v0.4.0
+          published_at: '2025-11-13T06:40:24Z'
+      - url: https://github.com/eclipse-uprotocol/.eclipsefdn
+        latest_release: null
       - url: https://github.com/eclipse-uprotocol/up-streamer-rust
         latest_release:
           tag_name: v0.1.0
@@ -1998,20 +2074,6 @@ categories:
           published_at: '2025-10-23T13:36:29Z'
       - url: https://github.com/eclipse-uprotocol/up-rust-py
         latest_release: null
-      - url: https://github.com/eclipse-uprotocol/.eclipsefdn
-        latest_release: null
-      - url: https://github.com/eclipse-uprotocol/up-rust
-        latest_release:
-          tag_name: v0.9.0
-          name: v0.9.0
-          url: https://github.com/eclipse-uprotocol/up-rust/releases/tag/v0.9.0
-          published_at: '2025-11-12T13:58:02Z'
-      - url: https://github.com/eclipse-uprotocol/up-transport-mqtt5-rust
-        latest_release:
-          tag_name: v0.4.0
-          name: v0.4.0
-          url: https://github.com/eclipse-uprotocol/up-transport-mqtt5-rust/releases/tag/v0.4.0
-          published_at: '2025-11-13T06:40:24Z'
       - url: https://github.com/eclipse-uprotocol/up-transport-vsomeip-rust
         latest_release:
           tag_name: v0.4.1
@@ -2038,12 +2100,6 @@ categories:
           published_at: '2024-08-16T00:58:31Z'
       - url: https://github.com/eclipse-uprotocol/symphony-target-example-rust
         latest_release: null
-      - url: https://github.com/eclipse-uprotocol/up-transport-zenoh-rust
-        latest_release:
-          tag_name: v0.9.0
-          name: v0.9.0
-          url: https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/releases/tag/v0.9.0
-          published_at: '2025-11-13T06:43:22Z'
       - url: https://github.com/eclipse-uprotocol/up-transport-iceoryx2-rust
         latest_release: null
       - url: https://github.com/eclipse-uprotocol/up-java
@@ -2066,8 +2122,6 @@ categories:
           name: v0.2.0-dev (up-spec v1.6.0-alpha.2)
           url: https://github.com/eclipse-uprotocol/up-python/releases/tag/v0.2.0-dev
           published_at: '2024-07-24T23:50:04Z'
-      - url: https://github.com/eclipse-uprotocol/ci-cd
-        latest_release: null
       - url: https://github.com/eclipse-uprotocol/up-conan-recipes
         latest_release: null
       - url: https://github.com/eclipse-uprotocol/eclipse-uprotocol.github.io
@@ -2153,36 +2207,43 @@ categories:
         The project delivers a modular, standards-compliant...
       homepage_url: https://projects.eclipse.org/projects/automotive.opensovd
       project: Incubating
-      repo_url: https://github.com/eclipse-opensovd/classic-diagnostic-adapter
+      repo_url: https://github.com/eclipse-opensovd
       repo_urls:
-      - https://github.com/eclipse-opensovd/classic-diagnostic-adapter
-      - https://github.com/eclipse-opensovd/cicd-workflows
       - https://github.com/eclipse-opensovd/opensovd-core
-      - https://github.com/eclipse-opensovd/opensovd
-      - https://github.com/eclipse-opensovd/odx-converter
-      - https://github.com/eclipse-opensovd/cpp-bindings
+      - https://github.com/eclipse-opensovd/cicd-workflows
+      - https://github.com/eclipse-opensovd/classic-diagnostic-adapter
       - https://github.com/eclipse-opensovd/.eclipsefdn
+      - https://github.com/eclipse-opensovd/odx-converter
+      - https://github.com/eclipse-opensovd/demo
       - https://github.com/eclipse-opensovd/uds2sovd-proxy
+      - https://github.com/eclipse-opensovd/opensovd
+      - https://github.com/eclipse-opensovd/cpp-bindings
       - https://github.com/eclipse-opensovd/dlt-tracing-lib
       - https://github.com/eclipse-opensovd/fault-lib
       - https://github.com/eclipse-opensovd/.github
       - https://github.com/eclipse-opensovd/website
       repositories:
-      - url: https://github.com/eclipse-opensovd/classic-diagnostic-adapter
-        latest_release: null
+      - url: https://github.com/eclipse-opensovd/opensovd-core
+        latest_release:
+          tag_name: latest
+          name: latest
+          url: https://github.com/eclipse-opensovd/opensovd-core/releases/tag/latest
+          published_at: '2026-05-05T11:55:10Z'
       - url: https://github.com/eclipse-opensovd/cicd-workflows
         latest_release: null
-      - url: https://github.com/eclipse-opensovd/opensovd-core
-        latest_release: null
-      - url: https://github.com/eclipse-opensovd/opensovd
-        latest_release: null
-      - url: https://github.com/eclipse-opensovd/odx-converter
-        latest_release: null
-      - url: https://github.com/eclipse-opensovd/cpp-bindings
+      - url: https://github.com/eclipse-opensovd/classic-diagnostic-adapter
         latest_release: null
       - url: https://github.com/eclipse-opensovd/.eclipsefdn
         latest_release: null
+      - url: https://github.com/eclipse-opensovd/odx-converter
+        latest_release: null
+      - url: https://github.com/eclipse-opensovd/demo
+        latest_release: null
       - url: https://github.com/eclipse-opensovd/uds2sovd-proxy
+        latest_release: null
+      - url: https://github.com/eclipse-opensovd/opensovd
+        latest_release: null
+      - url: https://github.com/eclipse-opensovd/cpp-bindings
         latest_release: null
       - url: https://github.com/eclipse-opensovd/dlt-tracing-lib
         latest_release:
@@ -2205,7 +2266,7 @@ categories:
         in software life cycle management. The Eclipse Ibeji project...
       homepage_url: https://projects.eclipse.org/projects/automotive.ibeji
       project: Incubating
-      repo_url: https://github.com/eclipse-ibeji/.github
+      repo_url: https://github.com/eclipse-ibeji
       repo_urls:
       - https://github.com/eclipse-ibeji/.github
       - https://github.com/eclipse-ibeji/.eclipsefdn
@@ -2246,22 +2307,26 @@ categories:
         redesigned for the unique constraints of automotive systems.
       homepage_url: https://projects.eclipse.org/projects/automotive.pullpiri
       project: Incubating
-      repo_url: https://github.com/eclipse-pullpiri/pullpiri
+      repo_url: https://github.com/eclipse-pullpiri
       repo_urls:
       - https://github.com/eclipse-pullpiri/pullpiri
-      - https://github.com/eclipse-pullpiri/.eclipsefdn
       - https://github.com/eclipse-pullpiri/pullpiri-dashboard
+      - https://github.com/eclipse-pullpiri/.eclipsefdn
       - https://github.com/eclipse-pullpiri/.github
       repositories:
       - url: https://github.com/eclipse-pullpiri/pullpiri
         latest_release:
-          tag_name: v0.4.0
-          name: Version 0.4.0 - Jan. 26, 2026
-          url: https://github.com/eclipse-pullpiri/pullpiri/releases/tag/v0.4.0
-          published_at: '2026-01-26T02:07:04Z'
-      - url: https://github.com/eclipse-pullpiri/.eclipsefdn
-        latest_release: null
+          tag_name: v0.5.0-1
+          name: v0.5.0-1
+          url: https://github.com/eclipse-pullpiri/pullpiri/releases/tag/v0.5.0-1
+          published_at: '2026-03-18T02:29:57Z'
       - url: https://github.com/eclipse-pullpiri/pullpiri-dashboard
+        latest_release:
+          tag_name: v26.04.03
+          name: v26.04.03
+          url: https://github.com/eclipse-pullpiri/pullpiri-dashboard/releases/tag/v26.04.03
+          published_at: '2026-04-03T01:28:39Z'
+      - url: https://github.com/eclipse-pullpiri/.eclipsefdn
         latest_release: null
       - url: https://github.com/eclipse-pullpiri/.github
         latest_release: null
@@ -2272,35 +2337,38 @@ categories:
         and workloads. It provides a central place to manage...
       homepage_url: https://projects.eclipse.org/projects/automotive.ankaios
       project: Incubating
-      repo_url: https://github.com/eclipse-ankaios/ank-sdk-python
+      repo_url: https://github.com/eclipse-ankaios
       repo_urls:
-      - https://github.com/eclipse-ankaios/ank-sdk-python
       - https://github.com/eclipse-ankaios/ankaios
+      - https://github.com/eclipse-ankaios/ank-sdk-python
       - https://github.com/eclipse-ankaios/ank-sdk-rust
-      - https://github.com/eclipse-ankaios/.eclipsefdn
       - https://github.com/eclipse-ankaios/.github
+      - https://github.com/eclipse-ankaios/meta-ankaios
+      - https://github.com/eclipse-ankaios/.eclipsefdn
       repositories:
-      - url: https://github.com/eclipse-ankaios/ank-sdk-python
-        latest_release:
-          tag_name: v1.0.0
-          name: v1.0.0
-          url: https://github.com/eclipse-ankaios/ank-sdk-python/releases/tag/v1.0.0
-          published_at: '2026-02-16T14:52:15Z'
       - url: https://github.com/eclipse-ankaios/ankaios
         latest_release:
           tag_name: v1.0.0
           name: v1.0.0
           url: https://github.com/eclipse-ankaios/ankaios/releases/tag/v1.0.0
           published_at: '2026-02-16T14:16:20Z'
+      - url: https://github.com/eclipse-ankaios/ank-sdk-python
+        latest_release:
+          tag_name: v1.0.1
+          name: v1.0.1
+          url: https://github.com/eclipse-ankaios/ank-sdk-python/releases/tag/v1.0.1
+          published_at: '2026-03-13T09:43:58Z'
       - url: https://github.com/eclipse-ankaios/ank-sdk-rust
         latest_release:
-          tag_name: v1.0.0
-          name: v1.0.0
-          url: https://github.com/eclipse-ankaios/ank-sdk-rust/releases/tag/v1.0.0
-          published_at: '2026-02-16T14:38:07Z'
-      - url: https://github.com/eclipse-ankaios/.eclipsefdn
-        latest_release: null
+          tag_name: v1.0.1
+          name: v1.0.1
+          url: https://github.com/eclipse-ankaios/ank-sdk-rust/releases/tag/v1.0.1
+          published_at: '2026-03-13T09:43:30Z'
       - url: https://github.com/eclipse-ankaios/.github
+        latest_release: null
+      - url: https://github.com/eclipse-ankaios/meta-ankaios
+        latest_release: null
+      - url: https://github.com/eclipse-ankaios/.eclipsefdn
         latest_release: null
       logo: Ankaios__logo_for_light_bgrd_clipped.png
     - name: Eclipse Symphony
@@ -2309,7 +2377,7 @@ categories:
         cost-effective, and consistent application...
       homepage_url: https://projects.eclipse.org/projects/iot.symphony
       project: Incubating
-      repo_url: https://github.com/eclipse-symphony/symphony
+      repo_url: https://github.com/eclipse-symphony
       repo_urls:
       - https://github.com/eclipse-symphony/symphony
       - https://github.com/eclipse-symphony/.eclipsefdn
@@ -2319,10 +2387,10 @@ categories:
       repositories:
       - url: https://github.com/eclipse-symphony/symphony
         latest_release:
-          tag_name: 0.48.44
-          name: Release 0.48.44
-          url: https://github.com/eclipse-symphony/symphony/releases/tag/0.48.44
-          published_at: '2025-11-28T05:52:25Z'
+          tag_name: 0.48.47
+          name: Release 0.48.47
+          url: https://github.com/eclipse-symphony/symphony/releases/tag/0.48.47
+          published_at: '2026-05-05T03:52:26Z'
       - url: https://github.com/eclipse-symphony/.eclipsefdn
         latest_release: null
       - url: https://github.com/eclipse-symphony/.github
@@ -2338,10 +2406,10 @@ categories:
         seamless with systemd via its D-Bus API relaying D-Bus...
       homepage_url: https://projects.eclipse.org/projects/automotive.bluechi
       project: Regular
-      repo_url: https://github.com/eclipse-bluechi/bluechi
+      repo_url: https://github.com/eclipse-bluechi
       repo_urls:
-      - https://github.com/eclipse-bluechi/bluechi
       - https://github.com/eclipse-bluechi/bluechi-ppa
+      - https://github.com/eclipse-bluechi/bluechi
       - https://github.com/eclipse-bluechi/bluechi-on-yocto
       - https://github.com/eclipse-bluechi/.eclipsefdn
       - https://github.com/eclipse-bluechi/.github
@@ -2350,14 +2418,14 @@ categories:
       - https://github.com/eclipse-bluechi/bluechi-ansible-collection
       - https://github.com/eclipse-bluechi/hashmap.c
       repositories:
+      - url: https://github.com/eclipse-bluechi/bluechi-ppa
+        latest_release: null
       - url: https://github.com/eclipse-bluechi/bluechi
         latest_release:
           tag_name: v1.2.2
           name: v1.2.2
           url: https://github.com/eclipse-bluechi/bluechi/releases/tag/v1.2.2
           published_at: '2026-02-03T12:56:13Z'
-      - url: https://github.com/eclipse-bluechi/bluechi-ppa
-        latest_release: null
       - url: https://github.com/eclipse-bluechi/bluechi-on-yocto
         latest_release: null
       - url: https://github.com/eclipse-bluechi/.eclipsefdn
@@ -2391,53 +2459,52 @@ categories:
         Imagine it like an operating system for your...
       homepage_url: https://projects.eclipse.org/projects/technology.lmos
       project: Incubating
-      repo_url: https://github.com/eclipse-lmos/arc
+      repo_url: https://github.com/eclipse-lmos
       repo_urls:
-      - https://github.com/eclipse-lmos/arc
       - https://github.com/eclipse-lmos/lmos-runtime
-      - https://github.com/eclipse-lmos/lmos-router
       - https://github.com/eclipse-lmos/lmos-operator
-      - https://github.com/eclipse-lmos/lmos-sample-agents
+      - https://github.com/eclipse-lmos/lmos-router
+      - https://github.com/eclipse-lmos/arc
+      - https://github.com/eclipse-lmos/adl
+      - https://github.com/eclipse-lmos/website
       - https://github.com/eclipse-lmos/.github
       - https://github.com/eclipse-lmos/.eclipsefdn
-      - https://github.com/eclipse-lmos/arc-spring-init
-      - https://github.com/eclipse-lmos/website
-      - https://github.com/eclipse-lmos/lmos-demo
       - https://github.com/eclipse-lmos/arc-view
+      - https://github.com/eclipse-lmos/lmos-sample-agents
+      - https://github.com/eclipse-lmos/arc-spring-init
+      - https://github.com/eclipse-lmos/lmos-demo
       - https://github.com/eclipse-lmos/lmos-kotlin-sdk
       - https://github.com/eclipse-lmos/lmos-kotlin-sdk-template
       - https://github.com/eclipse-lmos/lmos-cli
       repositories:
-      - url: https://github.com/eclipse-lmos/arc
-        latest_release:
-          tag_name: 0.212.0
-          name: 0.212.0
-          url: https://github.com/eclipse-lmos/arc/releases/tag/0.212.0
-          published_at: '2026-02-16T11:09:47Z'
       - url: https://github.com/eclipse-lmos/lmos-runtime
         latest_release:
-          tag_name: 0.25.0
-          name: 0.25.0
-          url: https://github.com/eclipse-lmos/lmos-runtime/releases/tag/0.25.0
-          published_at: '2026-01-21T09:31:20Z'
-      - url: https://github.com/eclipse-lmos/lmos-router
-        latest_release:
-          tag_name: 0.23.0
-          name: 0.23.0
-          url: https://github.com/eclipse-lmos/lmos-router/releases/tag/0.23.0
-          published_at: '2026-01-26T11:13:45Z'
+          tag_name: 0.31.0
+          name: 0.31.0
+          url: https://github.com/eclipse-lmos/lmos-runtime/releases/tag/0.31.0
+          published_at: '2026-04-27T08:02:47Z'
       - url: https://github.com/eclipse-lmos/lmos-operator
         latest_release:
-          tag_name: 0.9.0
-          name: 0.9.0
-          url: https://github.com/eclipse-lmos/lmos-operator/releases/tag/0.9.0
-          published_at: '2026-01-29T08:47:02Z'
-      - url: https://github.com/eclipse-lmos/lmos-sample-agents
+          tag_name: 0.10.0
+          name: 0.10.0
+          url: https://github.com/eclipse-lmos/lmos-operator/releases/tag/0.10.0
+          published_at: '2026-04-29T13:46:13Z'
+      - url: https://github.com/eclipse-lmos/lmos-router
         latest_release:
-          tag_name: 0.1.0
-          name: 0.1.0
-          url: https://github.com/eclipse-lmos/lmos-sample-agents/releases/tag/0.1.0
-          published_at: '2025-03-13T17:02:57Z'
+          tag_name: 0.28.0
+          name: 0.28.0
+          url: https://github.com/eclipse-lmos/lmos-router/releases/tag/0.28.0
+          published_at: '2026-04-27T07:28:01Z'
+      - url: https://github.com/eclipse-lmos/arc
+        latest_release:
+          tag_name: 0.225.0
+          name: 0.225.0
+          url: https://github.com/eclipse-lmos/arc/releases/tag/0.225.0
+          published_at: '2026-04-28T16:46:59Z'
+      - url: https://github.com/eclipse-lmos/adl
+        latest_release: null
+      - url: https://github.com/eclipse-lmos/website
+        latest_release: null
       - url: https://github.com/eclipse-lmos/.github
         latest_release:
           tag_name: 0.0.1-M1
@@ -2446,13 +2513,17 @@ categories:
           published_at: null
       - url: https://github.com/eclipse-lmos/.eclipsefdn
         latest_release: null
+      - url: https://github.com/eclipse-lmos/arc-view
+        latest_release: null
+      - url: https://github.com/eclipse-lmos/lmos-sample-agents
+        latest_release:
+          tag_name: 0.1.0
+          name: 0.1.0
+          url: https://github.com/eclipse-lmos/lmos-sample-agents/releases/tag/0.1.0
+          published_at: '2025-03-13T17:02:57Z'
       - url: https://github.com/eclipse-lmos/arc-spring-init
         latest_release: null
-      - url: https://github.com/eclipse-lmos/website
-        latest_release: null
       - url: https://github.com/eclipse-lmos/lmos-demo
-        latest_release: null
-      - url: https://github.com/eclipse-lmos/arc-view
         latest_release: null
       - url: https://github.com/eclipse-lmos/lmos-kotlin-sdk
         latest_release: null
@@ -2488,7 +2559,7 @@ categories:
         for capabilities of SDV. In the field of highly...
       homepage_url: https://projects.eclipse.org/projects/automotive.sdv-lvl
       project: Incubating
-      repo_url: https://github.com/eclipse-sdv-lvl/.eclipsefdn
+      repo_url: https://github.com/eclipse-sdv-lvl
       repo_urls:
       - https://github.com/eclipse-sdv-lvl/.eclipsefdn
       - https://github.com/eclipse-sdv-lvl/sdv-lvl
@@ -2509,7 +2580,7 @@ categories:
         Eclipse SommR fosters...'
       homepage_url: https://projects.eclipse.org/projects/automotive.sommr
       project: Archived
-      repo_url: https://github.com/eclipse-sommr/.github
+      repo_url: https://github.com/eclipse-sommr
       repo_urls:
       - https://github.com/eclipse-sommr/.github
       - https://github.com/eclipse-sommr/.eclipsefdn

--- a/tools/generate_data_static.py
+++ b/tools/generate_data_static.py
@@ -350,7 +350,7 @@ def build_landscape_from_static(
             project, release_cache, org_repo_cache
         )
         if repo_urls:
-            item["repo_url"] = repo_urls[0]
+            item["repo_url"] = f"https://github.com/{project.get('github', {}).get('org')}" if project.get("github", {}).get("org") else repo_urls[0]
             item["repo_urls"] = repo_urls
             item["repositories"] = repositories
         logo_url = project.get("logo")


### PR DESCRIPTION
The current key rep_url was assigned like this

```python
item["repo_url"] = repo_urls[0]
```

This lead to the fact that tin e.g. KUKSA the current data set lists a long archived/deprecated Repo. This unfortunately is also shown on the rendered version of the landscape

Worse, when I reran the generator on the next run _another_ repo was at `repo_urls[0]`, so it seems random. 

I changed the code now, so that it adds the Github org as primary "repo". While that may not be semantically correct, for omst projects it is usually a better entry point than "random repo"

(actually I was not even sure why there is even a "repo_urls" list, as this seems quite redundant to the information in the "repositories" branch but I just want a fix, not a refactor :D )

I also updated the data file, as there were a lot of changes in version etc. anyway, but also happy to split that out, if that is preferred


